### PR TITLE
Clear up 3.2.x situation

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,11 @@
 Some Android plugin versions have issues with Gradle's build cache feature. When applied to an Android project this plugin applies workarounds for these issues based on the Android plugin and Gradle versions.
 
 * Supported Gradle versions: 4.1+
-* Supported Android versions: 3.0.0, 3.0.1, 3.1.0, 3.1.1, 3.1.2, 3.2.0-alpha01
+* Supported Android versions: 3.0.0, 3.0.1, 3.1.0, 3.1.1, 3.1.2, 3.1.3
 
-**Note:** With Android 3.1.x and 3.2.x the cache-fix plugin is only required if you are using Android's data binding feature.
+**Note:** With Android 3.1.x the cache-fix plugin is only required if you are using Android's data binding feature.
+
+**Note:** With Android 3.2.x the cache-fix plugin is not required.
 
 ## List of issues
 

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ import groovy.json.JsonBuilder
 buildscript {
     repositories {
         maven {
-            url "https://plugins.gradle.org/m2/"
+            url = "https://plugins.gradle.org/m2/"
         }
     }
     dependencies {
@@ -22,7 +22,7 @@ version = ["git", "describe", "--match", "[0-9]*", "--dirty"].execute().text.tri
 
 // Maps supported Android plugin versions to the versions of Gradle that support it
 def supportedVersions = [
-    "3.2.0-alpha01": ["4.5.1", "4.6", "4.7", "4.8.1"],
+    "3.2.0-alpha18": ["4.8.1"],
     "3.1.3": ["4.4.1", "4.5.1", "4.6", "4.7", "4.8.1"],
     "3.1.2": ["4.4.1"],
     "3.1.1": ["4.4.1"],

--- a/src/main/groovy/org/gradle/android/AndroidCacheFixPlugin.groovy
+++ b/src/main/groovy/org/gradle/android/AndroidCacheFixPlugin.groovy
@@ -22,9 +22,7 @@ import org.gradle.util.VersionNumber
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
-import static org.gradle.android.CompilerArgsProcessor.AnnotationProcessorOverride
-import static org.gradle.android.CompilerArgsProcessor.Skip
-import static org.gradle.android.CompilerArgsProcessor.SkipNext
+import static org.gradle.android.CompilerArgsProcessor.*
 import static org.gradle.android.Versions.android
 
 @CompileStatic
@@ -158,7 +156,7 @@ class AndroidCacheFixPlugin implements Plugin<Project> {
     /**
      * Override path sensitivity for {@link AndroidJavaCompile#getDataBindingDependencyArtifacts()} to {@link PathSensitivity#RELATIVE}.
      */
-    @AndroidIssue(introducedIn = "3.0.0", link = "https://issuetracker.google.com/issues/69243050")
+    @AndroidIssue(introducedIn = "3.0.0", fixedIn = "3.2.0-alpha18", link = "https://issuetracker.google.com/issues/69243050")
     static class DataBindingDependencyArtifacts_Workaround implements Workaround {
         @Override
         void apply(WorkaroundContext context) {
@@ -168,6 +166,7 @@ class AndroidCacheFixPlugin implements Plugin<Project> {
             compilerArgsProcessor.addRule(Skip.matching("-Aandroid.databinding.sdkDir=.*"))
             compilerArgsProcessor.addRule(Skip.matching("-Aandroid.databinding.bindingBuildFolder=.*"))
             compilerArgsProcessor.addRule(Skip.matching("-Aandroid.databinding.xmlOutDir=.*"))
+            compilerArgsProcessor.addRule(InputDirectory.withAnnotationProcessorArgument("android.databinding.baseFeatureInfo"))
 
             def outputRules = [
                 AnnotationProcessorOverride.of("android.databinding.generationalFileOutDir") { Task task, String path ->

--- a/src/main/groovy/org/gradle/android/AndroidCacheFixPlugin.groovy
+++ b/src/main/groovy/org/gradle/android/AndroidCacheFixPlugin.groovy
@@ -59,7 +59,9 @@ class AndroidCacheFixPlugin implements Plugin<Project> {
             workaround.apply(context)
         }
 
-        if (currentAndroidVersion.baseVersion >= android("3.1.0-alpha06")) {
+        if (currentAndroidVersion.baseVersion >= android("3.2.0")) {
+            LOGGER.warn("WARNING: Android cache-fix plugin is not required for {} when using Android plugin {} or later.", project, currentAndroidVersion)
+        } else if (currentAndroidVersion.baseVersion >= android("3.1.0")) {
             project.afterEvaluate {
                 if (!project.getExtensions().findByType(AndroidConfig)?.dataBinding?.enabled) {
                     LOGGER.warn("WARNING: Android cache-fix plugin is not required for {} when using Android plugin {} or later, unless Android data binding is used.", project, currentAndroidVersion)

--- a/src/main/groovy/org/gradle/android/CompilerArgsProcessor.groovy
+++ b/src/main/groovy/org/gradle/android/CompilerArgsProcessor.groovy
@@ -5,6 +5,8 @@ import groovy.transform.CompileStatic
 import groovy.transform.TypeCheckingMode
 import org.gradle.api.Project
 import org.gradle.api.Task
+import org.gradle.api.tasks.PathSensitivity
+import org.gradle.api.tasks.TaskInputs
 import org.gradle.internal.BiAction
 
 import java.util.regex.Matcher
@@ -20,7 +22,7 @@ class CompilerArgsProcessor {
         this.project = project
         this.rules = [new Rule(Pattern.compile(".*")) {
             @Override
-            void process(Matcher match, Collection<String> processedArgs, Iterator<String> remainingArgs) {
+            void process(Matcher match, Collection<String> processedArgs, Iterator<String> remainingArgs, TaskInputs inputs) {
                 processedArgs.add(match.group())
             }
         }] as List<Rule>
@@ -41,14 +43,14 @@ class CompilerArgsProcessor {
         project.tasks.withType(AndroidJavaCompile) { AndroidJavaCompile task ->
             project.gradle.taskGraph.beforeTask {
                 if (task == it) {
-                    def processedArgs = processArgs(task.options.compilerArgs)
+                    def processedArgs = processArgs(task.options.compilerArgs, task.inputs)
                     overrideProperty(task, processedArgs)
                 }
             }
         }
     }
 
-    List<String> processArgs(List<String> args) {
+    List<String> processArgs(List<String> args, TaskInputs inputs) {
         def processedArgs = []
         def remainingArgs = args.iterator()
         while (remainingArgs.hasNext()) {
@@ -56,7 +58,7 @@ class CompilerArgsProcessor {
             for (Rule rule : rules) {
                 def matcher = rule.pattern.matcher(arg)
                 if (matcher.matches()) {
-                    rule.process(matcher, processedArgs, remainingArgs)
+                    rule.process(matcher, processedArgs, remainingArgs, inputs)
                     break
                 }
             }
@@ -83,7 +85,7 @@ class CompilerArgsProcessor {
             return new AnnotationProcessorOverride(property, action)
         }
 
-        void process(Matcher match, Collection<String> processedArgs, Iterator<String> remainingArgs) {
+        void process(Matcher match, Collection<String> processedArgs, Iterator<String> remainingArgs, TaskInputs inputs) {
             // Skip the arg
         }
 
@@ -103,6 +105,26 @@ class CompilerArgsProcessor {
         }
     }
 
+    static class InputDirectory extends Rule {
+        private final String argumentName
+
+        InputDirectory(String argumentName) {
+            super(Pattern.compile("-A" + Pattern.quote(argumentName) + "=(.*)"))
+            this.argumentName = argumentName
+        }
+
+        static InputDirectory withAnnotationProcessorArgument(String argumentName) {
+            return new InputDirectory(argumentName)
+        }
+
+        @Override
+        void process(Matcher match, Collection<String> processedArgs, Iterator<String> remainingArgs, TaskInputs inputs) {
+            inputs.dir(match.group(1))
+                .withPathSensitivity(PathSensitivity.RELATIVE)
+                .withPropertyName(argumentName)
+        }
+    }
+
     static class Skip extends Rule {
         Skip(Pattern pattern) {
             super(pattern)
@@ -113,7 +135,7 @@ class CompilerArgsProcessor {
         }
 
         @Override
-        void process(Matcher match, Collection<String> processedArgs, Iterator<String> remainingArgs) {
+        void process(Matcher match, Collection<String> processedArgs, Iterator<String> remainingArgs, TaskInputs inputs) {
         }
     }
 
@@ -127,7 +149,7 @@ class CompilerArgsProcessor {
         }
 
         @Override
-        void process(Matcher match, Collection<String> processedArgs, Iterator<String> remainingArgs) {
+        void process(Matcher match, Collection<String> processedArgs, Iterator<String> remainingArgs, TaskInputs inputs) {
             if (remainingArgs.hasNext()) {
                 remainingArgs.next()
             }
@@ -141,7 +163,7 @@ class CompilerArgsProcessor {
             this.pattern = pattern
         }
 
-        abstract void process(Matcher match, Collection<String> processedArgs, Iterator<String> remainingArgs)
+        abstract void process(Matcher match, Collection<String> processedArgs, Iterator<String> remainingArgs, TaskInputs inputs)
 
         @Override
         String toString() {

--- a/src/main/groovy/org/gradle/android/CompilerArgsProcessor.groovy
+++ b/src/main/groovy/org/gradle/android/CompilerArgsProcessor.groovy
@@ -3,6 +3,7 @@ package org.gradle.android
 import com.android.build.gradle.tasks.factory.AndroidJavaCompile
 import groovy.transform.CompileStatic
 import groovy.transform.TypeCheckingMode
+import org.gradle.android.CompilerArgsProcessor.Rule
 import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.tasks.PathSensitivity

--- a/src/test/groovy/org/gradle/android/CompilerArgsProcessorTest.groovy
+++ b/src/test/groovy/org/gradle/android/CompilerArgsProcessorTest.groovy
@@ -2,6 +2,7 @@ package org.gradle.android
 
 import org.gradle.api.Project
 import org.gradle.api.Task
+import org.gradle.api.tasks.TaskInputs
 import spock.lang.Specification
 
 import static org.gradle.android.CompilerArgsProcessor.AnnotationProcessorOverride
@@ -9,7 +10,7 @@ import static org.gradle.android.CompilerArgsProcessor.Skip
 import static org.gradle.android.CompilerArgsProcessor.SkipNext
 
 class CompilerArgsProcessorTest extends Specification {
-    def task = null
+    def inputs = Stub(TaskInputs)
     CompilerArgsProcessor processor
 
     def setup() {
@@ -18,22 +19,22 @@ class CompilerArgsProcessorTest extends Specification {
 
     def "processes arguments by default"() {
         expect:
-        processor.processArgs([]) == []
-        processor.processArgs(["alma", "bela", "-switch"]) == ["alma", "bela", "-switch"]
+        processor.processArgs([], inputs) == []
+        processor.processArgs(["alma", "bela", "-switch"], inputs) == ["alma", "bela", "-switch"]
     }
 
     def "can skip arg"() {
         processor.addRule(Skip.matching("-s"))
         expect:
-        processor.processArgs([]) == []
-        processor.processArgs(["alma", "bela", "-s", "-switch"]) == ["alma", "bela", "-switch"]
+        processor.processArgs([], inputs) == []
+        processor.processArgs(["alma", "bela", "-s", "-switch"], inputs) == ["alma", "bela", "-switch"]
     }
 
     def "can skip multiple args"() {
         processor.addRule(SkipNext.matching("-s"))
         expect:
-        processor.processArgs([]) == []
-        processor.processArgs(["alma", "bela", "-s", "file.txt", "-switch"]) == ["alma", "bela", "-switch"]
+        processor.processArgs([], inputs) == []
+        processor.processArgs(["alma", "bela", "-s", "file.txt", "-switch"], inputs) == ["alma", "bela", "-switch"]
     }
 
     def "can override annotation processor parameters"() {
@@ -47,8 +48,8 @@ class CompilerArgsProcessorTest extends Specification {
         processor.addRule(rule)
 
         expect:
-        processor.processArgs([]) == []
-        processor.processArgs(args) == ["alma", "bela", "-Abela=123"]
+        processor.processArgs([], inputs) == []
+        processor.processArgs(args, inputs) == ["alma", "bela", "-Abela=123"]
 
         when:
         rule.configureTask(task, args)

--- a/src/test/groovy/org/gradle/android/PluginApplicationTest.groovy
+++ b/src/test/groovy/org/gradle/android/PluginApplicationTest.groovy
@@ -23,10 +23,9 @@ class PluginApplicationTest extends AbstractTest {
     }
 
     @Unroll
-    def "does #description about being useless for Android version #androidVersion (data binding: #dataBinding)"() {
+    def "#desc warning for being useless with Android version #androidVersion (data binding: #dataBinding)"() {
         def projectDir = temporaryFolder.newFolder()
         new SimpleAndroidApp(projectDir, cacheDir, androidVersion, dataBinding).writeProject()
-        def message = "WARNING: Android cache-fix plugin is not required for project ':library' when using Android plugin $androidVersion or later, unless Android data binding is used."
 
         expect:
         def result = withGradleVersion(Iterables.getLast(Versions.SUPPORTED_GRADLE_VERSIONS).version)
@@ -34,28 +33,28 @@ class PluginApplicationTest extends AbstractTest {
             .withArguments("tasks")
             .withDebug(true)
             .build()
-        if (warns) {
-            assert result.output.contains(message)
+        if (message == null) {
+            assert !result.output.contains("WARNING: Android cache-fix plugin is not required")
         } else {
-            assert !(result.output.contains(message))
+            assert result.output.contains(message)
         }
 
         where:
-        warns | dataBinding | androidVersion
-        false | true        | "3.0.0"
-        false | false       | "3.0.0"
-        false | true        | "3.0.1"
-        false | false       | "3.0.1"
-        false | true        | "3.1.0"
-        true  | false       | "3.1.0"
-        false | true        | "3.1.1"
-        true  | false       | "3.1.1"
-        false | true        | "3.1.2"
-        true  | false       | "3.1.2"
-        false | true        | "3.1.3"
-        true  | false       | "3.1.3"
-        false | true        | "3.2.0-alpha18"
-        true  | false       | "3.2.0-alpha18"
-        description = warns ? "warn" : "not warn"
+        dataBinding | androidVersion       | message
+        true        | "3.0.0"              | null
+        false       | "3.0.0"              | null
+        true        | "3.0.1"              | null
+        false       | "3.0.1"              | null
+        true        | "3.1.0"              | null
+        false       | "3.1.0"              | "WARNING: Android cache-fix plugin is not required for project ':library' when using Android plugin 3.1.0 or later, unless Android data binding is used."
+        true        | "3.1.1"              | null
+        false       | "3.1.1"              | "WARNING: Android cache-fix plugin is not required for project ':library' when using Android plugin 3.1.1 or later, unless Android data binding is used."
+        true        | "3.1.2"              | null
+        false       | "3.1.2"              | "WARNING: Android cache-fix plugin is not required for project ':library' when using Android plugin 3.1.2 or later, unless Android data binding is used."
+        true        | "3.1.3"              | null
+        false       | "3.1.3"              | "WARNING: Android cache-fix plugin is not required for project ':library' when using Android plugin 3.1.3 or later, unless Android data binding is used."
+        true        | "3.2.0-alpha18"      | "WARNING: Android cache-fix plugin is not required for project ':library' when using Android plugin 3.2.0-alpha18 or later."
+        false       | "3.2.0-alpha18"      | "WARNING: Android cache-fix plugin is not required for project ':library' when using Android plugin 3.2.0-alpha18 or later."
+        desc = message == null ? "does not print" : "prints"
     }
 }

--- a/src/test/groovy/org/gradle/android/PluginApplicationTest.groovy
+++ b/src/test/groovy/org/gradle/android/PluginApplicationTest.groovy
@@ -52,8 +52,10 @@ class PluginApplicationTest extends AbstractTest {
         true  | false       | "3.1.1"
         false | true        | "3.1.2"
         true  | false       | "3.1.2"
-        false | true        | "3.2.0-alpha01"
-        true  | false       | "3.2.0-alpha01"
+        false | true        | "3.1.3"
+        true  | false       | "3.1.3"
+        false | true        | "3.2.0-alpha18"
+        true  | false       | "3.2.0-alpha18"
         description = warns ? "warn" : "not warn"
     }
 }

--- a/src/test/groovy/org/gradle/android/WorkaroundTest.groovy
+++ b/src/test/groovy/org/gradle/android/WorkaroundTest.groovy
@@ -35,5 +35,13 @@ class WorkaroundTest extends Specification {
         "3.1.2"         | ["DataBindingDependencyArtifacts"]
         "3.1.3"         | ["DataBindingDependencyArtifacts"]
         "3.2.0-alpha01" | ["DataBindingDependencyArtifacts"]
+        "3.2.0-alpha02" | ["DataBindingDependencyArtifacts"]
+        "3.2.0-alpha03" | ["DataBindingDependencyArtifacts"]
+        "3.2.0-alpha04" | ["DataBindingDependencyArtifacts"]
+        "3.2.0-alpha05" | ["DataBindingDependencyArtifacts"]
+        "3.2.0-alpha06" | ["DataBindingDependencyArtifacts"]
+        "3.2.0-alpha07" | ["DataBindingDependencyArtifacts"]
+        "3.2.0-alpha09" | ["DataBindingDependencyArtifacts"]
+        "3.2.0-alpha18" | []
     }
 }


### PR DESCRIPTION
We can now be explicit that AGP 3.2.0 does not need the cache-fix plugin anymore.