### PR TITLE
Make room schema workaround work with KaptWithKotlincTask

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: android
 
 install: ./gradlew assemble
-script: ./gradlew check
+script: ./gradlew -I gradle/buildScanInit.gradle check 
 
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock

--- a/README.md
+++ b/README.md
@@ -10,15 +10,15 @@ Some Android plugin versions have issues with Gradle's build cache feature. When
 ## Applying the plugin
 
 This plugin should be applied anywhere the `com.android.application` or `com.android.library` plugins are applied.  Typically,
-this can just be injected from the root project's build.gradle (change '1.0.1' to the latest version of the cache fix plugin
+this can just be injected from the root project's build.gradle (change '1.0.2' to the latest version of the cache fix plugin
 [here](https://plugins.gradle.org/plugin/org.gradle.android.cache-fix)):
 ```$groovy
 plugins {
-  id "org.gradle.android.cache-fix" version "1.0.1" apply false
+  id "org.gradle.android.cache-fix" version "1.0.2" apply false
 }
 
 subprojects {
-    apply plugin: 'android-cache-fix`
+    apply plugin: 'org.gradle.android-cache-fix`
 }
 ```
 

--- a/gradle/buildScanInit.gradle
+++ b/gradle/buildScanInit.gradle
@@ -1,0 +1,44 @@
+import com.gradle.enterprise.gradleplugin.GradleEnterprisePlugin
+import com.gradle.scan.plugin.BuildScanPlugin
+import org.gradle.util.GradleVersion
+
+initscript {
+    def pluginVersion = "3.3"
+
+    repositories {
+        gradlePluginPortal()
+    }
+    dependencies {
+        classpath("com.gradle:gradle-enterprise-gradle-plugin:${pluginVersion}")
+    }
+}
+
+def isTopLevelBuild = gradle.getParent() == null
+
+if (isTopLevelBuild) {
+    def gradleVersion = GradleVersion.current().baseVersion
+    def atLeastGradle5 = gradleVersion >= GradleVersion.version("5.0")
+    def atLeastGradle6 = gradleVersion >= GradleVersion.version("6.0")
+
+    if (atLeastGradle6) {
+        settingsEvaluated {
+            if (!it.pluginManager.hasPlugin("com.gradle.enterprise")) {
+                it.pluginManager.apply(GradleEnterprisePlugin)
+            }
+            configureExtension(it.extensions["gradleEnterprise"])
+        }
+    } else if (atLeastGradle5) {
+        rootProject {
+            pluginManager.apply(BuildScanPlugin)
+            configureExtension(extensions["gradleEnterprise"])
+        }
+    }
+}
+
+void configureExtension(extension) {
+    extension.buildScan.with {
+        termsOfServiceUrl = "https://gradle.com/terms-of-service"
+        termsOfServiceAgree = "yes"
+        publishAlways()
+    }
+}

--- a/src/main/groovy/org/gradle/android/workarounds/AbstractAbsolutePathWorkaround.groovy
+++ b/src/main/groovy/org/gradle/android/workarounds/AbstractAbsolutePathWorkaround.groovy
@@ -11,6 +11,11 @@ abstract class AbstractAbsolutePathWorkaround implements Workaround {
     abstract void setPropertyValue(Task task, FileCollection fileCollection)
 
     @Override
+    boolean canBeApplied(Project project) {
+        return true
+    }
+
+    @Override
     void apply(WorkaroundContext context) {
         Project project = context.project
         project.tasks.withType(androidTaskClass).configureEach { Task task ->

--- a/src/main/groovy/org/gradle/android/workarounds/Workaround.groovy
+++ b/src/main/groovy/org/gradle/android/workarounds/Workaround.groovy
@@ -1,7 +1,11 @@
 package org.gradle.android.workarounds
+
+import org.gradle.api.Project
+
 /**
  * Workaround to apply to an Android project. Can be annotated with {@literal @}{@link AndroidIssue}.
  */
 interface Workaround {
     void apply(WorkaroundContext context)
+    boolean canBeApplied(Project project)
 }

--- a/src/test/groovy/org/gradle/android/SimpleAndroidApp.groovy
+++ b/src/test/groovy/org/gradle/android/SimpleAndroidApp.groovy
@@ -8,15 +8,17 @@ class SimpleAndroidApp {
     final File projectDir
     private final File cacheDir
     final VersionNumber androidVersion
+    final VersionNumber kotlinVersion
     private final boolean dataBindingEnabled
     private final boolean kotlinEnabled
     private final boolean kaptWorkersEnabled
 
-    private SimpleAndroidApp(File projectDir, File cacheDir, VersionNumber androidVersion, boolean dataBindingEnabled, boolean kotlinEnabled, boolean kaptWorkersEnabled) {
+    private SimpleAndroidApp(File projectDir, File cacheDir, VersionNumber androidVersion, VersionNumber kotlinVersion, boolean dataBindingEnabled, boolean kotlinEnabled, boolean kaptWorkersEnabled) {
         this.dataBindingEnabled = dataBindingEnabled
         this.projectDir = projectDir
         this.cacheDir = cacheDir
         this.androidVersion = androidVersion
+        this.kotlinVersion = kotlinVersion
         this.kotlinEnabled = kotlinEnabled
         this.kaptWorkersEnabled = kaptWorkersEnabled
     }
@@ -115,7 +117,7 @@ class SimpleAndroidApp {
 
     private String getKotlinPluginDependencyIfEnabled() {
         return kotlinEnabled ? """
-            classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.71"
+            classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${kotlinVersion}"
         """ : ""
     }
 
@@ -381,6 +383,7 @@ class SimpleAndroidApp {
         boolean kotlinEnabled = true
         boolean kaptWorkersEnabled = true
         VersionNumber androidVersion = Versions.latestAndroidVersion()
+        VersionNumber kotlinVersion = VersionNumber.parse("1.3.72")
         File projectDir
         File cacheDir
 
@@ -396,6 +399,11 @@ class SimpleAndroidApp {
 
         Builder withKotlinDisabled() {
             this.kotlinEnabled = false
+            return this
+        }
+
+        Builder withKotlinVersion(VersionNumber kotlinVersion) {
+            this.kotlinVersion = kotlinVersion
             return this
         }
 
@@ -424,7 +432,7 @@ class SimpleAndroidApp {
         }
 
         SimpleAndroidApp build() {
-            return new SimpleAndroidApp(projectDir, cacheDir, androidVersion, dataBindingEnabled, kotlinEnabled, kaptWorkersEnabled)
+            return new SimpleAndroidApp(projectDir, cacheDir, androidVersion, kotlinVersion, dataBindingEnabled, kotlinEnabled, kaptWorkersEnabled)
         }
     }
 }

--- a/src/test/groovy/org/gradle/android/WorkaroundTest.groovy
+++ b/src/test/groovy/org/gradle/android/WorkaroundTest.groovy
@@ -7,7 +7,7 @@ class WorkaroundTest extends Specification {
 
     @Unroll
     def "applies the right workarounds for Android #androidVersion"() {
-        def workarounds = AndroidCacheFixPlugin.getWorkaroundsToApply(Versions.android(androidVersion))
+        def workarounds = AndroidCacheFixPlugin.getWorkaroundsToApply(Versions.android(androidVersion), null)
         expect:
         workarounds.collect { it.class.simpleName.replaceAll(/Workaround/, "") }.sort() == expectedWorkarounds.sort()
         where:


### PR DESCRIPTION
Previously, the room schema workaround would not be applied when `kapt.use.worker.api=false` because this causes the kapt tasks to use a different type (`KaptWithKotlincTask`) which stores the annotation processor options differently and evaluates relative paths differently.

This fixes the workaround so that it will also work when this option is set.  It also checks the Kotlin Gradle plugin version and punts if a version < 1.3.70 is used as the annotation processor options are stored differently on earlier versions and it's more difficult/complex to handle those additional cases.  For now, we only support 1.3.70 and higher.