### PR TITLE
Task specific room schema dir is populated with existing schemas

### DIFF
--- a/src/test/groovy/org/gradle/android/RoomSchemaLocationWorkaroundTest.groovy
+++ b/src/test/groovy/org/gradle/android/RoomSchemaLocationWorkaroundTest.groovy
@@ -231,7 +231,9 @@ class RoomSchemaLocationWorkaroundTest extends AbstractTest {
 
     void assertMergedSchemaOutputsExist() {
         // Merged schemas
+        assert file("app/schemas/org.gradle.android.example.app.AppDatabase/1.json").exists()
         assert file("app/schemas/org.gradle.android.example.app.AppDatabase/2.json").exists()
+        assert file("library/schemas/org.gradle.android.example.library.AppDatabase/1.json").exists()
         assert file("library/schemas/org.gradle.android.example.library.AppDatabase/2.json").exists()
     }
 }

--- a/src/test/groovy/org/gradle/android/RoomSchemaLocationWorkaroundTest.groovy
+++ b/src/test/groovy/org/gradle/android/RoomSchemaLocationWorkaroundTest.groovy
@@ -215,25 +215,34 @@ class RoomSchemaLocationWorkaroundTest extends AbstractTest {
 
     void assertKaptSchemaOutputsExist() {
         // Task specific schemas
-        assert file("app/build/roomSchemas/kaptDebugKotlin/org.gradle.android.example.app.AppDatabase/2.json").exists()
-        assert file("app/build/roomSchemas/kaptReleaseKotlin/org.gradle.android.example.app.AppDatabase/2.json").exists()
-        assert file("library/build/roomSchemas/kaptDebugKotlin/org.gradle.android.example.library.AppDatabase/2.json").exists()
-        assert file("library/build/roomSchemas/kaptReleaseKotlin/org.gradle.android.example.library.AppDatabase/2.json").exists()
+        assertKaptSchemaOutputsExistFor("debug")
+        assertKaptSchemaOutputsExistFor("release")
+    }
+
+    void assertKaptSchemaOutputsExistFor(String variant) {
+        assertSchemasExist("app", "build/roomSchemas/kapt${variant.capitalize()}Kotlin")
+        assertSchemasExist("library", "build/roomSchemas/kapt${variant.capitalize()}Kotlin")
     }
 
     void assertCompileJavaSchemaOutputsExist() {
         // Task specific schemas
-        assert file("app/build/roomSchemas/compileDebugJavaWithJavac/org.gradle.android.example.app.AppDatabase/2.json").exists()
-        assert file("app/build/roomSchemas/compileReleaseJavaWithJavac/org.gradle.android.example.app.AppDatabase/2.json").exists()
-        assert file("library/build/roomSchemas/compileDebugJavaWithJavac/org.gradle.android.example.library.AppDatabase/2.json").exists()
-        assert file("library/build/roomSchemas/compileReleaseJavaWithJavac/org.gradle.android.example.library.AppDatabase/2.json").exists()
+        assertCompileJavaSchemaOutputExistsFor("debug")
+        assertCompileJavaSchemaOutputExistsFor("release")
+    }
+
+    void assertCompileJavaSchemaOutputExistsFor(String variant) {
+        assertSchemasExist("app", "build/roomSchemas/compile${variant.capitalize()}JavaWithJavac")
+        assertSchemasExist("library", "build/roomSchemas/compile${variant.capitalize()}JavaWithJavac")
     }
 
     void assertMergedSchemaOutputsExist() {
         // Merged schemas
-        assert file("app/schemas/org.gradle.android.example.app.AppDatabase/1.json").exists()
-        assert file("app/schemas/org.gradle.android.example.app.AppDatabase/2.json").exists()
-        assert file("library/schemas/org.gradle.android.example.library.AppDatabase/1.json").exists()
-        assert file("library/schemas/org.gradle.android.example.library.AppDatabase/2.json").exists()
+        assertSchemasExist("app", "schemas")
+        assertSchemasExist("library", "schemas")
+    }
+
+    void assertSchemasExist(String project, String baseDirPath) {
+        assert file("${project}/${baseDirPath}/org.gradle.android.example.${project}.AppDatabase/1.json").exists()
+        assert file("${project}/${baseDirPath}/org.gradle.android.example.${project}.AppDatabase/2.json").exists()
     }
 }

--- a/src/test/groovy/org/gradle/android/SimpleAndroidApp.groovy
+++ b/src/test/groovy/org/gradle/android/SimpleAndroidApp.groovy
@@ -257,6 +257,9 @@ class SimpleAndroidApp {
 
                     @ColumnInfo(name = "last_name")
                     public String lastName;
+
+                    @ColumnInfo(name = "last_update")
+                    public int lastUpdate;
                 }
             """.stripIndent()
 
@@ -328,6 +331,55 @@ class SimpleAndroidApp {
                 }
             }
         """.stripIndent()
+
+        file("${basedir}/schemas/${packageName}.AppDatabase/1.json") << '''
+            {
+              "formatVersion": 1,
+              "database": {
+                "version": 1,
+                "identityHash": "ce7bbbf6ddf39482eddc7248f4f61e8a",
+                "entities": [
+                  {
+                    "tableName": "user",
+                    "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uid` INTEGER NOT NULL, `first_name` TEXT, `last_name` TEXT, PRIMARY KEY(`uid`))",
+                    "fields": [
+                      {
+                        "fieldPath": "uid",
+                        "columnName": "uid",
+                        "affinity": "INTEGER",
+                        "notNull": true
+                      },
+                      {
+                        "fieldPath": "firstName",
+                        "columnName": "first_name",
+                        "affinity": "TEXT",
+                        "notNull": false
+                      },
+                      {
+                        "fieldPath": "lastName",
+                        "columnName": "last_name",
+                        "affinity": "TEXT",
+                        "notNull": false
+                      }
+                    ],
+                    "primaryKey": {
+                      "columnNames": [
+                        "uid"
+                      ],
+                      "autoGenerate": false
+                    },
+                    "indices": [],
+                    "foreignKeys": []
+                  }
+                ],
+                "views": [],
+                "setupQueries": [
+                  "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+                  "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'ce7bbbf6ddf39482eddc7248f4f61e8a')"
+                ]
+              }
+            }
+        '''.stripIndent()
 
         file("${basedir}/src/main/res/layout/${resourceName}_layout.xml") << '''<?xml version="1.0" encoding="utf-8"?>
                 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"


### PR DESCRIPTION
Sometimes other annotation processors use the room schema location annotation processor argument to do further processing of schemas and expect the existing schemas to also be present (not just the newly generated schemas).  This change allows the task specific directory to be seeded with the existing schemas before starting the compilation process.