### PR TITLE
Add early support for AGP 4.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ bin/
 # Logs
 # ----
 *.log
+
+# Android Studio
+local.properties

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath "com.gradle.publish:plugin-publish-plugin:0.11.0"
+        classpath "com.gradle.publish:plugin-publish-plugin:0.12.0"
     }
 }
 
@@ -22,6 +22,8 @@ version = ["git", "describe", "--match", "[0-9]*", "--dirty"].execute().text.tri
 
 // Maps supported Android plugin versions to the versions of Gradle that support it
 def supportedVersions = [
+    // 4.1.0-alpha10 is *only* compatible with milestone 1
+    "4.1.0-alpha10": ["6.5-milestone-1"],
     "4.0.0": ["6.1.1", "6.3", "6.4.1"],
     "3.6.3": ["5.6.4", "6.3", "6.4.1"],
     "3.6.2": ["5.6.4"],
@@ -39,10 +41,9 @@ repositories {
 }
 
 dependencies {
-    compileOnly 'com.android.tools.build:gradle:3.5.0'
-    compile 'com.google.guava:guava:22.0'
+    compileOnly 'com.android.tools.build:gradle:3.5.3'
     compile gradleApi()
-    testCompile 'com.android.tools.build:gradle:3.5.0'
+    testCompile 'com.android.tools.build:gradle:3.5.3'
     testCompile gradleTestKit()
     testCompile "junit:junit:4.12"
     testCompile "org.spockframework:spock-core:1.1-groovy-2.4@jar"
@@ -107,15 +108,9 @@ task install(type: Upload) {
     configuration = configurations.runtime
 }
 
-def travis = System.getenv("TRAVIS") == "true"
-
 test {
     dependsOn install
     systemProperty "local.repo", localRepo.toURI()
-    systemProperty "travis", travis
-    if (travis) {
-        testLogging.showStandardStreams = true
-    }
 }
 
 if (!JavaVersion.current().java8) {

--- a/gradle/buildScanInit.gradle
+++ b/gradle/buildScanInit.gradle
@@ -3,7 +3,7 @@ import com.gradle.scan.plugin.BuildScanPlugin
 import org.gradle.util.GradleVersion
 
 initscript {
-    def pluginVersion = "3.3"
+    def pluginVersion = "3.3.3"
 
     repositories {
         gradlePluginPortal()

--- a/src/main/groovy/org/gradle/android/workarounds/MergeJavaResourcesWorkaround.groovy
+++ b/src/main/groovy/org/gradle/android/workarounds/MergeJavaResourcesWorkaround.groovy
@@ -12,7 +12,7 @@ import java.lang.reflect.Method
  * absolute path sensitivity.  This mostly comes up when the kotlin plugin has been applied, which puts the
  * kotlin_module files into this input.
  */
-@AndroidIssue(introducedIn = "3.5.0", fixedIn = ["4.1.0"], link = "https://issuetracker.google.com/issues/140602655")
+@AndroidIssue(introducedIn = "3.5.0", fixedIn = ["4.1.0-alpha09"], link = "https://issuetracker.google.com/issues/140602655")
 class MergeJavaResourcesWorkaround extends AbstractAbsolutePathWorkaround {
     Class<?> androidTaskClass = MergeJavaResourceTask.class
     String propertyName = "projectJavaRes"

--- a/src/main/groovy/org/gradle/android/workarounds/MergeNativeLibsWorkaround.groovy
+++ b/src/main/groovy/org/gradle/android/workarounds/MergeNativeLibsWorkaround.groovy
@@ -16,7 +16,7 @@ import java.lang.reflect.Field
  * method that calculates a new FileCollection from variantScope every time it is called.  So we only
  * support this workaround for 3.6.x and 4.0.x.
  */
-@AndroidIssue(introducedIn = "3.6.0", fixedIn = ["4.1.0"], link = "https://issuetracker.google.com/issues/140602655")
+@AndroidIssue(introducedIn = "3.6.0", fixedIn = ["4.1.0-alpha09"], link = "https://issuetracker.google.com/issues/140602655")
 class MergeNativeLibsWorkaround extends AbstractAbsolutePathWorkaround {
     Class<?> androidTaskClass = MergeNativeLibsTask.class
     String propertyName = "projectNativeLibs"

--- a/src/test/groovy/org/gradle/android/CrossVersionOutcomeAndRelocationTest.groovy
+++ b/src/test/groovy/org/gradle/android/CrossVersionOutcomeAndRelocationTest.groovy
@@ -133,10 +133,13 @@ class CrossVersionOutcomeAndRelocationTest extends AbstractTest {
         def isAndroid35xOrHigher = androidVersion >= android("3.5.0")
         def isAndroid350to352 = androidVersion >= android("3.5.0") && androidVersion <= android("3.5.2")
         def isAndroid35x = androidVersion >= android("3.5.0") && androidVersion < android("3.6.0")
-        def isAndroid35xTo36x= androidVersion >= android("3.5.0") && androidVersion <= android("3.6.3")
+        def isAndroid35xTo36x = androidVersion >= android("3.5.0") && androidVersion <= android("3.6.3")
+        def isAndroid35xTo40x = androidVersion >= android("3.5.0") && androidVersion <= android("4.1.0-alpha01")
         def isAndroid36x = androidVersion >= android("3.6.0") && androidVersion < android("4.0.0-alpha01")
         def isAndroid36xOrHigher = androidVersion >= android("3.6.0")
         def isAndroid40xOrHigher = androidVersion >= android("4.0.0-beta01")
+        def isAndroid40x = androidVersion >= android("4.0.0") && androidVersion < android("4.1.0-alpha01")
+        def isAndroid41xOrHigher = androidVersion >= android("4.1.0-alpha01")
         def builder = new ExpectedOutcomeBuilder()
 
         // Applies to anything 3.5.0 or higher
@@ -174,6 +177,19 @@ class CrossVersionOutcomeAndRelocationTest extends AbstractTest {
             android40xOrHigherExpectations(builder)
         }
 
+        if (isAndroid35xTo40x) {
+            android35xTo40xExpectations(builder)
+        }
+
+        if (isAndroid40x) {
+            android40xOnlyExpectations(builder)
+        }
+
+        // Applies to anything 4.1.0 or higher
+        if (isAndroid41xOrHigher) {
+            android41xOrHigherExpectations(builder)
+        }
+
         new ExpectedResults(
             builder.build()
         )
@@ -197,8 +213,6 @@ class CrossVersionOutcomeAndRelocationTest extends AbstractTest {
         builder.expect(':app:compileReleaseSources', UP_TO_DATE)
         builder.expect(':app:createDebugCompatibleScreenManifests', FROM_CACHE)
         builder.expect(':app:createReleaseCompatibleScreenManifests', FROM_CACHE)
-        builder.expect(':app:dataBindingExportFeaturePackageIdsDebug', FROM_CACHE)
-        builder.expect(':app:dataBindingExportFeaturePackageIdsRelease', FROM_CACHE)
         builder.expect(':app:dataBindingGenBaseClassesDebug', FROM_CACHE)
         builder.expect(':app:dataBindingGenBaseClassesRelease', FROM_CACHE)
         builder.expect(':app:dataBindingMergeDependencyArtifactsDebug', FROM_CACHE)
@@ -207,12 +221,10 @@ class CrossVersionOutcomeAndRelocationTest extends AbstractTest {
         builder.expect(':app:generateDebugBuildConfig', FROM_CACHE)
         builder.expect(':app:generateDebugResValues', FROM_CACHE)
         builder.expect(':app:generateDebugResources', UP_TO_DATE)
-        builder.expect(':app:generateDebugSources', SUCCESS)
         builder.expect(':app:generateReleaseAssets', UP_TO_DATE)
         builder.expect(':app:generateReleaseBuildConfig', FROM_CACHE)
         builder.expect(':app:generateReleaseResValues', FROM_CACHE)
         builder.expect(':app:generateReleaseResources', UP_TO_DATE)
-        builder.expect(':app:generateReleaseSources', SUCCESS)
         builder.expect(':app:javaPreCompileDebug', FROM_CACHE)
         builder.expect(':app:javaPreCompileRelease', FROM_CACHE)
         builder.expect(':app:kaptGenerateStubsDebugKotlin', FROM_CACHE)
@@ -240,7 +252,6 @@ class CrossVersionOutcomeAndRelocationTest extends AbstractTest {
         builder.expect(':app:preDebugBuild', UP_TO_DATE)
         builder.expect(':app:preReleaseBuild', UP_TO_DATE)
         builder.expect(':app:prepareLintJar', SUCCESS)
-        builder.expect(':app:prepareLintJarForPublish', SUCCESS)
         builder.expect(':app:processDebugJavaRes', NO_SOURCE)
         builder.expect(':app:processDebugManifest', FROM_CACHE)
         builder.expect(':app:processReleaseJavaRes', NO_SOURCE)
@@ -274,13 +285,11 @@ class CrossVersionOutcomeAndRelocationTest extends AbstractTest {
         builder.expect(':library:generateDebugRFile', FROM_CACHE)
         builder.expect(':library:generateDebugResValues', FROM_CACHE)
         builder.expect(':library:generateDebugResources', UP_TO_DATE)
-        builder.expect(':library:generateDebugSources', SUCCESS)
         builder.expect(':library:generateReleaseAssets', UP_TO_DATE)
         builder.expect(':library:generateReleaseBuildConfig', FROM_CACHE)
         builder.expect(':library:generateReleaseRFile', FROM_CACHE)
         builder.expect(':library:generateReleaseResValues', FROM_CACHE)
         builder.expect(':library:generateReleaseResources', UP_TO_DATE)
-        builder.expect(':library:generateReleaseSources', SUCCESS)
         builder.expect(':library:javaPreCompileDebug', FROM_CACHE)
         builder.expect(':library:javaPreCompileRelease', FROM_CACHE)
         builder.expect(':library:kaptGenerateStubsDebugKotlin', FROM_CACHE)
@@ -304,7 +313,6 @@ class CrossVersionOutcomeAndRelocationTest extends AbstractTest {
         builder.expect(':library:preBuild', UP_TO_DATE)
         builder.expect(':library:preDebugBuild', UP_TO_DATE)
         builder.expect(':library:preReleaseBuild', UP_TO_DATE)
-        builder.expect(':library:prepareLintJar', SUCCESS)
         builder.expect(':library:prepareLintJarForPublish', SUCCESS)
         builder.expect(':library:processDebugJavaRes', NO_SOURCE)
         builder.expect(':library:processDebugManifest', FROM_CACHE)
@@ -346,6 +354,17 @@ class CrossVersionOutcomeAndRelocationTest extends AbstractTest {
         builder.expect(':library:mergeDebugGeneratedProguardFiles', SUCCESS)
         builder.expect(':library:mergeReleaseConsumerProguardFiles', SUCCESS)
         builder.expect(':library:mergeReleaseGeneratedProguardFiles', SUCCESS)
+    }
+
+    static void android35xTo40xExpectations(ExpectedOutcomeBuilder builder) {
+        builder.expect(':app:prepareLintJarForPublish', SUCCESS)
+        builder.expect(':app:dataBindingExportFeaturePackageIdsDebug', FROM_CACHE)
+        builder.expect(':app:dataBindingExportFeaturePackageIdsRelease', FROM_CACHE)
+        builder.expect(':app:generateDebugSources', SUCCESS)
+        builder.expect(':app:generateReleaseSources', SUCCESS)
+        builder.expect(':library:generateDebugSources', SUCCESS)
+        builder.expect(':library:generateReleaseSources', SUCCESS)
+        builder.expect(':library:prepareLintJar', SUCCESS)
     }
 
     static void android35xOnlyExpectations(ExpectedOutcomeBuilder builder) {
@@ -405,8 +424,6 @@ class CrossVersionOutcomeAndRelocationTest extends AbstractTest {
     static void android40xOrHigherExpectations(ExpectedOutcomeBuilder builder) {
         builder.expect(':app:compileDebugShaders', NO_SOURCE)
         builder.expect(':app:compileReleaseShaders', NO_SOURCE)
-        builder.expect(':app:dataBindingExportBuildInfoDebug', FROM_CACHE)
-        builder.expect(':app:dataBindingExportBuildInfoRelease', FROM_CACHE)
         builder.expect(':app:dataBindingMergeGenClassesDebug', FROM_CACHE)
         builder.expect(':app:dataBindingMergeGenClassesRelease', FROM_CACHE)
         builder.expect(':app:mergeDebugResources', SUCCESS)
@@ -417,8 +434,6 @@ class CrossVersionOutcomeAndRelocationTest extends AbstractTest {
         builder.expect(':library:compileDebugShaders', NO_SOURCE)
         builder.expect(':library:compileReleaseLibraryResources', SUCCESS)
         builder.expect(':library:compileReleaseShaders', NO_SOURCE)
-        builder.expect(':library:dataBindingExportBuildInfoDebug', FROM_CACHE)
-        builder.expect(':library:dataBindingExportBuildInfoRelease', FROM_CACHE)
         builder.expect(':library:dataBindingMergeGenClassesDebug', FROM_CACHE)
         builder.expect(':library:dataBindingMergeGenClassesRelease', FROM_CACHE)
         builder.expect(':library:mergeDebugConsumerProguardFiles', FROM_CACHE)
@@ -433,5 +448,27 @@ class CrossVersionOutcomeAndRelocationTest extends AbstractTest {
         builder.expect(':library:bundleLibRuntimeToJarRelease', FROM_CACHE)
         builder.expect(':app:collectReleaseDependencies', SUCCESS)
         builder.expect(':app:sdkReleaseDependencyData', SUCCESS)
+    }
+
+    static void android41xOrHigherExpectations(ExpectedOutcomeBuilder builder) {
+        builder.expect(':library:dataBindingTriggerDebug', FROM_CACHE)
+        builder.expect(':library:dataBindingTriggerRelease', FROM_CACHE)
+        builder.expect(':app:dataBindingTriggerDebug', FROM_CACHE)
+        builder.expect(':app:processDebugMainManifest', FROM_CACHE)
+        builder.expect(':app:processDebugManifestForPackage', FROM_CACHE)
+        builder.expect(':app:dataBindingTriggerRelease', FROM_CACHE)
+        builder.expect(':app:processReleaseMainManifest', FROM_CACHE)
+        builder.expect(':app:processReleaseManifestForPackage', FROM_CACHE)
+        builder.expect(':app:compressDebugAssets', FROM_CACHE)
+        builder.expect(':app:compressReleaseAssets', FROM_CACHE)
+        builder.expect(':app:mergeDebugNativeDebugMetadata', NO_SOURCE)
+        builder.expect(':app:mergeReleaseNativeDebugMetadata', NO_SOURCE)
+    }
+
+    static void android40xOnlyExpectations(ExpectedOutcomeBuilder builder) {
+        builder.expect(':app:dataBindingExportBuildInfoDebug', FROM_CACHE)
+        builder.expect(':app:dataBindingExportBuildInfoRelease', FROM_CACHE)
+        builder.expect(':library:dataBindingExportBuildInfoDebug', FROM_CACHE)
+        builder.expect(':library:dataBindingExportBuildInfoRelease', FROM_CACHE)
     }
 }

--- a/src/test/groovy/org/gradle/android/PluginApplicationTest.groovy
+++ b/src/test/groovy/org/gradle/android/PluginApplicationTest.groovy
@@ -23,7 +23,8 @@ class PluginApplicationTest extends AbstractTest {
         result.output =~ /Android plugin ${quote(androidVersion)} is not supported by Android cache fix plugin. Supported Android plugin versions: .*. Override with -Dorg.gradle.android.cache-fix.ignoreVersionCheck=true./
 
         where:
-        androidVersion << ["3.4.1", "4.1.0-alpha01"]
+        androidVersion << ["3.4.1"] // TODO https://github.com/gradle/android-cache-fix-gradle-plugin/issues/95 Add 4.2.x when released.
+
     }
 
     // Temporarily ignored until we come up with a better way of testing this that doesn't introduce flakiness

--- a/src/test/groovy/org/gradle/android/WorkaroundTest.groovy
+++ b/src/test/groovy/org/gradle/android/WorkaroundTest.groovy
@@ -12,6 +12,7 @@ class WorkaroundTest extends Specification {
         workarounds.collect { it.class.simpleName.replaceAll(/Workaround/, "") }.sort() == expectedWorkarounds.sort()
         where:
         androidVersion  | expectedWorkarounds
+        "4.1.0-alpha10"  | ['RoomSchemaLocation']
         "4.0.0-beta04"  | ['MergeJavaResources', 'MergeNativeLibs', 'RoomSchemaLocation']
         "3.6.2"         | ['MergeJavaResources', 'MergeNativeLibs', 'RoomSchemaLocation']
         "3.6.1"         | ['MergeJavaResources', 'MergeNativeLibs', 'RoomSchemaLocation']


### PR DESCRIPTION
Also bump versions and add local.properties to gitignore.
The travis property is removed since the build scan plugin is now applied to the tests.