### PR TITLE
Fix applying fixes to newer versions.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,8 +22,8 @@ version = ["git", "describe", "--match", "[0-9]*", "--dirty"].execute().text.tri
 
 // Maps supported Android plugin versions to the versions of Gradle that support it
 def supportedVersions = [
-    // 4.1.0-alpha10 is *only* compatible with milestone 1
-    "4.1.0-beta01": ["6.5"],
+    "4.2.0-alpha04": ["6.5.1"],
+    "4.1.0-beta03": ["6.5.1"],
     "4.0.0": ["6.1.1", "6.3", "6.4.1"],
     "3.6.3": ["5.6.4", "6.3", "6.4.1"],
     "3.6.2": ["5.6.4"],

--- a/src/main/groovy/org/gradle/android/AndroidCacheFixPlugin.groovy
+++ b/src/main/groovy/org/gradle/android/AndroidCacheFixPlugin.groovy
@@ -102,7 +102,7 @@ class AndroidCacheFixPlugin implements Plugin<Project> {
 
             if (androidIssue.fixedIn().any { String fixedInVersionString ->
                 def fixedInVersion = android(fixedInVersionString)
-                androidVersion.baseVersion == fixedInVersion.baseVersion && androidVersion >= fixedInVersion
+                androidVersion.baseVersion == fixedInVersion.baseVersion || androidVersion >= fixedInVersion
             }) {
                 continue
             }

--- a/src/test/groovy/org/gradle/android/PluginApplicationTest.groovy
+++ b/src/test/groovy/org/gradle/android/PluginApplicationTest.groovy
@@ -23,7 +23,7 @@ class PluginApplicationTest extends AbstractTest {
         result.output =~ /Android plugin ${quote(androidVersion)} is not supported by Android cache fix plugin. Supported Android plugin versions: .*. Override with -Dorg.gradle.android.cache-fix.ignoreVersionCheck=true./
 
         where:
-        androidVersion << ["3.4.1", "4.2.0-alpha01"]
+        androidVersion << ["3.4.1"]
 
     }
 

--- a/src/test/groovy/org/gradle/android/WorkaroundTest.groovy
+++ b/src/test/groovy/org/gradle/android/WorkaroundTest.groovy
@@ -12,7 +12,8 @@ class WorkaroundTest extends Specification {
         workarounds.collect { it.class.simpleName.replaceAll(/Workaround/, "") }.sort() == expectedWorkarounds.sort()
         where:
         androidVersion  | expectedWorkarounds
-        "4.1.0-alpha10" | ['RoomSchemaLocation', 'CompileLibraryResources']
+        "4.2.0-alpha04" | ['RoomSchemaLocation', 'CompileLibraryResources']
+        "4.1.0-beta04" | ['RoomSchemaLocation', 'CompileLibraryResources']
         "4.0.0"         | ['MergeJavaResources', 'MergeNativeLibs', 'RoomSchemaLocation', 'CompileLibraryResources']
         "3.6.2"         | ['MergeJavaResources', 'MergeNativeLibs', 'RoomSchemaLocation']
         "3.6.1"         | ['MergeJavaResources', 'MergeNativeLibs', 'RoomSchemaLocation']


### PR DESCRIPTION
There was a small bug in the logic which was causing the fixes to be applied to versions that are newer than the fixed version.

Fixes #99
