### PR TITLE
Add support for AGP 4.2.0-alpha07

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ version = ["git", "describe", "--match", "[0-9]*", "--dirty"].execute().text.tri
 
 // Maps supported Android plugin versions to the versions of Gradle that support it
 def supportedVersions = [
-    "4.2.0-alpha05": ["6.5.1"],
+    "4.2.0-alpha07": ["6.5.1"],
     "4.1.0-beta05": ["6.5.1"],
     "4.0.1": ["6.1.1", "6.3", "6.4.1"],
     "3.6.4": ["5.6.4", "6.3", "6.4.1"],

--- a/src/main/groovy/org/gradle/android/Versions.groovy
+++ b/src/main/groovy/org/gradle/android/Versions.groovy
@@ -41,7 +41,8 @@ class Versions {
 
     static VersionNumber earliestMaybeSupportedAndroidVersion() {
         VersionNumber earliestSupported = SUPPORTED_ANDROID_VERSIONS.min()
-        return new VersionNumber(earliestSupported.major, earliestSupported.minor, 0, null)
+        // "alpha" is lower than null
+        return new VersionNumber(earliestSupported.major, earliestSupported.minor, 0, "alpha")
     }
 
     static VersionNumber latestAndroidVersion() {

--- a/src/test/groovy/org/gradle/android/VersionsTest.groovy
+++ b/src/test/groovy/org/gradle/android/VersionsTest.groovy
@@ -1,0 +1,14 @@
+package org.gradle.android
+
+import org.junit.Assert
+import org.junit.Test
+
+class VersionsTest {
+
+    @Test
+    void "earliest supported version includes alpha and beta builds"() {
+        def earliest = Versions.SUPPORTED_ANDROID_VERSIONS.min()
+        def alphaOfEarliest = Versions.android("${earliest.major}.${earliest.minor}.0-alpha01")
+        Assert.assertTrue(alphaOfEarliest >= Versions.earliestMaybeSupportedAndroidVersion())
+    }
+}

--- a/src/test/groovy/org/gradle/android/WorkaroundTest.groovy
+++ b/src/test/groovy/org/gradle/android/WorkaroundTest.groovy
@@ -12,7 +12,7 @@ class WorkaroundTest extends Specification {
         workarounds.collect { it.class.simpleName.replaceAll(/Workaround/, "") }.sort() == expectedWorkarounds.sort()
         where:
         androidVersion  | expectedWorkarounds
-        "4.2.0-alpha05" | ['RoomSchemaLocation', 'CompileLibraryResources', 'MergeResources']
+        "4.2.0-alpha07" | ['RoomSchemaLocation', 'CompileLibraryResources', 'MergeResources']
         "4.1.0-beta05"  | ['RoomSchemaLocation', 'CompileLibraryResources', 'MergeResources']
         "4.0.1"         | ['MergeJavaResources', 'MergeNativeLibs', 'RoomSchemaLocation', 'CompileLibraryResources', 'MergeResources']
         "3.6.4"         | ['MergeJavaResources', 'MergeNativeLibs', 'RoomSchemaLocation']


### PR DESCRIPTION
The previous way of calculating the minimum supported version was always higher than beta and alpha version. This caused problems when testing alpha and beta versions in isolation.