### PR TITLE
Disable lint checks for tests.

### DIFF
--- a/src/test/groovy/org/gradle/android/CrossVersionOutcomeAndRelocationTest.groovy
+++ b/src/test/groovy/org/gradle/android/CrossVersionOutcomeAndRelocationTest.groovy
@@ -244,7 +244,6 @@ class CrossVersionOutcomeAndRelocationTest extends AbstractTest {
         builder.expect(':app:kaptDebugKotlin', FROM_CACHE)
         builder.expect(':app:kaptGenerateStubsReleaseKotlin', FROM_CACHE)
         builder.expect(':app:kaptReleaseKotlin', FROM_CACHE)
-        builder.expect(':app:lintVitalRelease', SUCCESS)
         builder.expect(':app:mergeDebugResources', FROM_CACHE)
         builder.expect(':app:mergeReleaseResources', FROM_CACHE)
         builder.expect(':app:processDebugResources', FROM_CACHE)

--- a/src/test/groovy/org/gradle/android/SimpleAndroidApp.groovy
+++ b/src/test/groovy/org/gradle/android/SimpleAndroidApp.groovy
@@ -156,6 +156,9 @@ class SimpleAndroidApp {
                         }
                     }
                 }
+                lintOptions {
+                    checkReleaseBuilds = false
+                }
             }
 
             ${renderscriptConfiguration}


### PR DESCRIPTION
They are starting to fail and also add considerable testing time and memory consumption.
