### PR TITLE
README update: Apply plugin only on Android projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,9 @@ plugins {
 }
 
 subprojects {
-    apply plugin: "org.gradle.android.cache-fix"
+    plugins.withType(com.android.build.gradle.BasePlugin) {
+        project.apply plugin: "org.gradle.android.cache-fix"
+    }
 }
 ```
 


### PR DESCRIPTION
Updated README to include code on how to apply plugin only on Android subprojects.