### PR TITLE
Only apply Room configuration to main compile tasks

### DIFF
--- a/src/main/groovy/org/gradle/android/workarounds/RoomSchemaLocationWorkaround.groovy
+++ b/src/main/groovy/org/gradle/android/workarounds/RoomSchemaLocationWorkaround.groovy
@@ -165,7 +165,7 @@ class RoomSchemaLocationWorkaround implements Workaround {
         }
     }
 
-    private static def getKaptRoomSchemaLocationArgumentProvider(Task task) {
+    private static KaptRoomSchemaLocationArgumentProvider getKaptRoomSchemaLocationArgumentProvider(Task task) {
         def annotationProcessorOptionProviders = getAccessibleField(task.class, "annotationProcessorOptionProviders").get(task)
         return annotationProcessorOptionProviders.flatten().find { it instanceof KaptRoomSchemaLocationArgumentProvider }
     }
@@ -209,6 +209,9 @@ class RoomSchemaLocationWorkaround implements Workaround {
     private static void copyExistingSchemasToTaskSpecificTmpDirForKapt(Task task, Provider<Directory> existingSchemaDir) {
         // Derive the variant directory from the command line provider it is configured with
         def provider = getKaptRoomSchemaLocationArgumentProvider(task)
+        if (provider == null) {
+            return
+        }
         def temporaryVariantSpecificSchemaDir = provider.temporarySchemaLocationDir
 
         // Populate the variant-specific temporary schema dir with the existing schemas
@@ -221,6 +224,9 @@ class RoomSchemaLocationWorkaround implements Workaround {
         // the existing schemas before the annotation processors run
         // Derive the variant directory from the command line provider it is configured with
         def provider = getKaptRoomSchemaLocationArgumentProvider(task)
+        if (provider == null) {
+            return
+        }
         def variantSpecificSchemaDir = provider.schemaLocationDir
         def temporaryVariantSpecificSchemaDir = provider.temporarySchemaLocationDir
 

--- a/src/test/groovy/org/gradle/android/RoomSchemaLocationWorkaroundTest.groovy
+++ b/src/test/groovy/org/gradle/android/RoomSchemaLocationWorkaroundTest.groovy
@@ -6,8 +6,13 @@ import org.gradle.testkit.runner.TaskOutcome
 import org.gradle.util.VersionNumber
 import spock.lang.Unroll
 
+import static org.gradle.testkit.runner.TaskOutcome.FROM_CACHE
+import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
+
 class RoomSchemaLocationWorkaroundTest extends AbstractTest {
-    private static final String[] CLEAN_BUILD = ["clean", "testDebug", "testRelease", "--build-cache", "--stacktrace"]
+    private static final String[] CLEAN_BUILD = ["clean", "testDebug", "testRelease", "assembleAndroidTest", "--build-cache", "--stacktrace"]
+    private static final List<String> ALL_PROJECTS = ["app", "library"]
+    private static final List<String> ALL_VARIANTS = ["debug", "release"]
 
     @Unroll
     def "schemas are generated into task-specific directory and are cacheable with kotlin and kapt workers enabled (Android #androidVersion)"() {
@@ -27,12 +32,14 @@ class RoomSchemaLocationWorkaroundTest extends AbstractTest {
             .build()
 
         then:
-        buildResult.task(':app:kaptDebugKotlin').outcome == TaskOutcome.SUCCESS
-        buildResult.task(':app:kaptReleaseKotlin').outcome == TaskOutcome.SUCCESS
-        buildResult.task(':library:kaptDebugKotlin').outcome == TaskOutcome.SUCCESS
-        buildResult.task(':library:kaptReleaseKotlin').outcome == TaskOutcome.SUCCESS
-        buildResult.task(':app:mergeRoomSchemaLocations').outcome == TaskOutcome.SUCCESS
-        buildResult.task(':library:mergeRoomSchemaLocations').outcome == TaskOutcome.SUCCESS
+        assertCompileTasksHaveOutcome(buildResult, SUCCESS)
+        assertCompileAndroidTestTasksHaveOutcome(buildResult, SUCCESS)
+        assertCompileUnitTestTasksHaveOutcome(buildResult, SUCCESS)
+        assertKaptTasksHaveOutcome(buildResult, SUCCESS)
+        assertKaptAndroidTestTasksHaveOutcome(buildResult, SUCCESS)
+        assertKaptUnitTestTasksHaveOutcome(buildResult, SUCCESS)
+        buildResult.task(':app:mergeRoomSchemaLocations').outcome == SUCCESS
+        buildResult.task(':library:mergeRoomSchemaLocations').outcome == SUCCESS
 
         and:
         assertKaptSchemaOutputsExist()
@@ -48,12 +55,14 @@ class RoomSchemaLocationWorkaroundTest extends AbstractTest {
             .build()
 
         then:
-        buildResult.task(':app:kaptDebugKotlin').outcome == TaskOutcome.FROM_CACHE
-        buildResult.task(':app:kaptReleaseKotlin').outcome == TaskOutcome.FROM_CACHE
-        buildResult.task(':library:kaptDebugKotlin').outcome == TaskOutcome.FROM_CACHE
-        buildResult.task(':library:kaptReleaseKotlin').outcome == TaskOutcome.FROM_CACHE
-        buildResult.task(':app:mergeRoomSchemaLocations').outcome == TaskOutcome.SUCCESS
-        buildResult.task(':library:mergeRoomSchemaLocations').outcome == TaskOutcome.SUCCESS
+        assertCompileTasksHaveOutcome(buildResult, FROM_CACHE)
+        assertCompileAndroidTestTasksHaveOutcome(buildResult, FROM_CACHE)
+        assertCompileUnitTestTasksHaveOutcome(buildResult, FROM_CACHE)
+        assertKaptTasksHaveOutcome(buildResult, FROM_CACHE)
+        assertKaptAndroidTestTasksHaveOutcome(buildResult, FROM_CACHE)
+        assertKaptUnitTestTasksHaveOutcome(buildResult, FROM_CACHE)
+        buildResult.task(':app:mergeRoomSchemaLocations').outcome == SUCCESS
+        buildResult.task(':library:mergeRoomSchemaLocations').outcome == SUCCESS
 
         and:
         assertKaptSchemaOutputsExist()
@@ -84,12 +93,14 @@ class RoomSchemaLocationWorkaroundTest extends AbstractTest {
             .build()
 
         then:
-        buildResult.task(':app:kaptDebugKotlin').outcome == TaskOutcome.SUCCESS
-        buildResult.task(':app:kaptReleaseKotlin').outcome == TaskOutcome.SUCCESS
-        buildResult.task(':library:kaptDebugKotlin').outcome == TaskOutcome.SUCCESS
-        buildResult.task(':library:kaptReleaseKotlin').outcome == TaskOutcome.SUCCESS
-        buildResult.task(':app:mergeRoomSchemaLocations').outcome == TaskOutcome.SUCCESS
-        buildResult.task(':library:mergeRoomSchemaLocations').outcome == TaskOutcome.SUCCESS
+        assertCompileTasksHaveOutcome(buildResult, SUCCESS)
+        assertCompileAndroidTestTasksHaveOutcome(buildResult, SUCCESS)
+        assertCompileUnitTestTasksHaveOutcome(buildResult, SUCCESS)
+        assertKaptTasksHaveOutcome(buildResult, SUCCESS)
+        assertKaptAndroidTestTasksHaveOutcome(buildResult, SUCCESS)
+        assertKaptUnitTestTasksHaveOutcome(buildResult, SUCCESS)
+        buildResult.task(':app:mergeRoomSchemaLocations').outcome == SUCCESS
+        buildResult.task(':library:mergeRoomSchemaLocations').outcome == SUCCESS
 
         and:
         assertKaptSchemaOutputsExist()
@@ -105,12 +116,14 @@ class RoomSchemaLocationWorkaroundTest extends AbstractTest {
             .build()
 
         then:
-        buildResult.task(':app:kaptDebugKotlin').outcome == TaskOutcome.FROM_CACHE
-        buildResult.task(':app:kaptReleaseKotlin').outcome == TaskOutcome.FROM_CACHE
-        buildResult.task(':library:kaptDebugKotlin').outcome == TaskOutcome.FROM_CACHE
-        buildResult.task(':library:kaptReleaseKotlin').outcome == TaskOutcome.FROM_CACHE
-        buildResult.task(':app:mergeRoomSchemaLocations').outcome == TaskOutcome.SUCCESS
-        buildResult.task(':library:mergeRoomSchemaLocations').outcome == TaskOutcome.SUCCESS
+        assertCompileTasksHaveOutcome(buildResult, FROM_CACHE)
+        assertCompileAndroidTestTasksHaveOutcome(buildResult, FROM_CACHE)
+        assertCompileUnitTestTasksHaveOutcome(buildResult, FROM_CACHE)
+        assertKaptTasksHaveOutcome(buildResult, FROM_CACHE)
+        assertKaptAndroidTestTasksHaveOutcome(buildResult, FROM_CACHE)
+        assertKaptUnitTestTasksHaveOutcome(buildResult, FROM_CACHE)
+        buildResult.task(':app:mergeRoomSchemaLocations').outcome == SUCCESS
+        buildResult.task(':library:mergeRoomSchemaLocations').outcome == SUCCESS
 
         and:
         assertKaptSchemaOutputsExist()
@@ -141,12 +154,11 @@ class RoomSchemaLocationWorkaroundTest extends AbstractTest {
             .build()
 
         then:
-        buildResult.task(':app:compileDebugJavaWithJavac').outcome == TaskOutcome.SUCCESS
-        buildResult.task(':app:compileReleaseJavaWithJavac').outcome == TaskOutcome.SUCCESS
-        buildResult.task(':library:compileDebugJavaWithJavac').outcome == TaskOutcome.SUCCESS
-        buildResult.task(':library:compileReleaseJavaWithJavac').outcome == TaskOutcome.SUCCESS
-        buildResult.task(':app:mergeRoomSchemaLocations').outcome == TaskOutcome.SUCCESS
-        buildResult.task(':library:mergeRoomSchemaLocations').outcome == TaskOutcome.SUCCESS
+        assertCompileTasksHaveOutcome(buildResult, SUCCESS)
+        assertCompileAndroidTestTasksHaveOutcome(buildResult, SUCCESS)
+        assertCompileUnitTestTasksHaveOutcome(buildResult, SUCCESS)
+        buildResult.task(':app:mergeRoomSchemaLocations').outcome == SUCCESS
+        buildResult.task(':library:mergeRoomSchemaLocations').outcome == SUCCESS
 
         and:
         assertCompileJavaSchemaOutputsExist()
@@ -162,12 +174,11 @@ class RoomSchemaLocationWorkaroundTest extends AbstractTest {
             .build()
 
         then:
-        buildResult.task(':app:compileDebugJavaWithJavac').outcome == TaskOutcome.FROM_CACHE
-        buildResult.task(':app:compileReleaseJavaWithJavac').outcome == TaskOutcome.FROM_CACHE
-        buildResult.task(':library:compileDebugJavaWithJavac').outcome == TaskOutcome.FROM_CACHE
-        buildResult.task(':library:compileReleaseJavaWithJavac').outcome == TaskOutcome.FROM_CACHE
-        buildResult.task(':app:mergeRoomSchemaLocations').outcome == TaskOutcome.SUCCESS
-        buildResult.task(':library:mergeRoomSchemaLocations').outcome == TaskOutcome.SUCCESS
+        assertCompileTasksHaveOutcome(buildResult, FROM_CACHE)
+        assertCompileAndroidTestTasksHaveOutcome(buildResult, FROM_CACHE)
+        assertCompileUnitTestTasksHaveOutcome(buildResult, FROM_CACHE)
+        buildResult.task(':app:mergeRoomSchemaLocations').outcome == SUCCESS
+        buildResult.task(':library:mergeRoomSchemaLocations').outcome == SUCCESS
 
         and:
         assertCompileJavaSchemaOutputsExist()
@@ -199,10 +210,12 @@ class RoomSchemaLocationWorkaroundTest extends AbstractTest {
             .build()
 
         then:
-        buildResult.task(':app:kaptDebugKotlin').outcome == TaskOutcome.SUCCESS
-        buildResult.task(':app:kaptReleaseKotlin').outcome == TaskOutcome.SUCCESS
-        buildResult.task(':library:kaptDebugKotlin').outcome == TaskOutcome.SUCCESS
-        buildResult.task(':library:kaptReleaseKotlin').outcome == TaskOutcome.SUCCESS
+        assertCompileTasksHaveOutcome(buildResult, SUCCESS)
+        assertCompileAndroidTestTasksHaveOutcome(buildResult, SUCCESS)
+        assertCompileUnitTestTasksHaveOutcome(buildResult, SUCCESS)
+        assertKaptTasksHaveOutcome(buildResult, SUCCESS)
+        assertKaptAndroidTestTasksHaveOutcome(buildResult, SUCCESS)
+        assertKaptUnitTestTasksHaveOutcome(buildResult, SUCCESS)
         buildResult.task(':app:mergeRoomSchemaLocations') == null
         buildResult.task(':library:mergeRoomSchemaLocations') == null
 
@@ -263,6 +276,42 @@ class RoomSchemaLocationWorkaroundTest extends AbstractTest {
 
     void assertNotExecuted(buildResult, String taskPath) {
         assert !buildResult.tasks.collect {it.path }.contains(taskPath)
+    }
+
+    void assertCompileTasksHaveOutcome(BuildResult buildResult, TaskOutcome outcome) {
+        assertAllVariantTasksHaveOutcome(buildResult, outcome) { project, variant -> ":${project}:compile${variant.capitalize()}JavaWithJavac" }
+    }
+
+    void assertCompileAndroidTestTasksHaveOutcome(BuildResult buildResult, TaskOutcome outcome) {
+        assertAllVariantTasksHaveOutcome(buildResult, outcome, ALL_PROJECTS, ["debug"]) { project, variant -> ":${project}:compile${variant.capitalize()}AndroidTestJavaWithJavac" }
+    }
+
+    void assertCompileUnitTestTasksHaveOutcome(BuildResult buildResult, TaskOutcome outcome) {
+        assertAllVariantTasksHaveOutcome(buildResult, outcome) { project, variant -> ":${project}:compile${variant.capitalize()}UnitTestJavaWithJavac" }
+    }
+
+    void assertKaptTasksHaveOutcome(BuildResult buildResult, TaskOutcome outcome) {
+        assertAllVariantTasksHaveOutcome(buildResult, outcome) { project, variant -> ":${project}:kapt${variant.capitalize()}Kotlin" }
+    }
+
+    void assertKaptAndroidTestTasksHaveOutcome(BuildResult buildResult, TaskOutcome outcome) {
+        assertAllVariantTasksHaveOutcome(buildResult, outcome, ALL_PROJECTS, ["debug"]) { project, variant -> ":${project}:kapt${variant.capitalize()}AndroidTestKotlin" }
+    }
+
+    void assertKaptUnitTestTasksHaveOutcome(BuildResult buildResult, TaskOutcome outcome) {
+        assertAllVariantTasksHaveOutcome(buildResult, outcome) { project, variant -> ":${project}:kapt${variant.capitalize()}UnitTestKotlin" }
+    }
+
+    void assertAllVariantTasksHaveOutcome(BuildResult buildResult, TaskOutcome taskOutcome, Closure<String> taskPathTransform) {
+        assertAllVariantTasksHaveOutcome(buildResult, taskOutcome, ALL_PROJECTS, ALL_VARIANTS, taskPathTransform)
+    }
+
+    void assertAllVariantTasksHaveOutcome(BuildResult buildResult, TaskOutcome taskOutcome, List<String> projects, List<String> variants, Closure<String> taskPathTransform) {
+        projects.each { project ->
+            variants.each { variant ->
+                assert buildResult.task(taskPathTransform.call(project, variant)).outcome == taskOutcome
+            }
+        }
     }
 
     void assertKaptSchemaOutputsExist() {

--- a/src/test/groovy/org/gradle/android/RoomSchemaLocationWorkaroundTest.groovy
+++ b/src/test/groovy/org/gradle/android/RoomSchemaLocationWorkaroundTest.groovy
@@ -7,6 +7,8 @@ import org.gradle.util.VersionNumber
 import spock.lang.Unroll
 
 class RoomSchemaLocationWorkaroundTest extends AbstractTest {
+    private static final String[] CLEAN_BUILD = ["clean", "testDebug", "testRelease", "--build-cache", "--stacktrace"]
+
     @Unroll
     def "schemas are generated into task-specific directory and are cacheable with kotlin and kapt workers enabled (Android #androidVersion)"() {
         SimpleAndroidApp.builder(temporaryFolder.root, cacheDir)
@@ -21,7 +23,7 @@ class RoomSchemaLocationWorkaroundTest extends AbstractTest {
         BuildResult buildResult = withGradleVersion(Versions.latestGradleVersion().version)
             .forwardOutput()
             .withProjectDir(temporaryFolder.root)
-            .withArguments("assemble", "testDebug", "--build-cache", "--stacktrace")
+            .withArguments(CLEAN_BUILD)
             .build()
 
         then:
@@ -42,7 +44,7 @@ class RoomSchemaLocationWorkaroundTest extends AbstractTest {
         buildResult = withGradleVersion(Versions.latestGradleVersion().version)
             .forwardOutput()
             .withProjectDir(temporaryFolder.root)
-            .withArguments("clean", "assemble", "--build-cache", "--stacktrace")
+            .withArguments(CLEAN_BUILD)
             .build()
 
         then:
@@ -78,7 +80,7 @@ class RoomSchemaLocationWorkaroundTest extends AbstractTest {
         BuildResult buildResult = withGradleVersion(Versions.latestGradleVersion().version)
             .forwardOutput()
             .withProjectDir(temporaryFolder.root)
-            .withArguments("assemble", "--build-cache", "--stacktrace")
+            .withArguments(CLEAN_BUILD)
             .build()
 
         then:
@@ -99,7 +101,7 @@ class RoomSchemaLocationWorkaroundTest extends AbstractTest {
         buildResult = withGradleVersion(Versions.latestGradleVersion().version)
             .forwardOutput()
             .withProjectDir(temporaryFolder.root)
-            .withArguments("clean", "assemble", "--build-cache", "--stacktrace")
+            .withArguments(CLEAN_BUILD)
             .build()
 
         then:
@@ -135,7 +137,7 @@ class RoomSchemaLocationWorkaroundTest extends AbstractTest {
         BuildResult buildResult = withGradleVersion(Versions.latestGradleVersion().version)
             .forwardOutput()
             .withProjectDir(temporaryFolder.root)
-            .withArguments("assemble", "--build-cache", "--stacktrace")
+            .withArguments(CLEAN_BUILD)
             .build()
 
         then:
@@ -156,7 +158,7 @@ class RoomSchemaLocationWorkaroundTest extends AbstractTest {
         buildResult = withGradleVersion(Versions.latestGradleVersion().version)
             .forwardOutput()
             .withProjectDir(temporaryFolder.root)
-            .withArguments("clean", "assemble", "--build-cache", "--stacktrace")
+            .withArguments(CLEAN_BUILD)
             .build()
 
         then:
@@ -193,7 +195,7 @@ class RoomSchemaLocationWorkaroundTest extends AbstractTest {
         BuildResult buildResult = withGradleVersion(Versions.latestGradleVersion().version)
             .forwardOutput()
             .withProjectDir(temporaryFolder.root)
-            .withArguments("assemble", "--build-cache", "--stacktrace", "--info")
+            .withArguments(CLEAN_BUILD + ['--info'] as String[])
             .build()
 
         then:
@@ -228,7 +230,7 @@ class RoomSchemaLocationWorkaroundTest extends AbstractTest {
         BuildResult buildResult = withGradleVersion(Versions.latestGradleVersion().version)
             .forwardOutput()
             .withProjectDir(temporaryFolder.root)
-            .withArguments("assemble", "--build-cache", "--stacktrace")
+            .withArguments(CLEAN_BUILD)
             .buildAndFail()
 
         then:
@@ -249,7 +251,7 @@ class RoomSchemaLocationWorkaroundTest extends AbstractTest {
         BuildResult buildResult = withGradleVersion(Versions.latestGradleVersion().version)
             .forwardOutput()
             .withProjectDir(temporaryFolder.root)
-            .withArguments("assemble", "--build-cache", "--stacktrace")
+            .withArguments(CLEAN_BUILD)
             .build()
 
         then:

--- a/src/test/groovy/org/gradle/android/RoomSchemaLocationWorkaroundTest.groovy
+++ b/src/test/groovy/org/gradle/android/RoomSchemaLocationWorkaroundTest.groovy
@@ -21,7 +21,7 @@ class RoomSchemaLocationWorkaroundTest extends AbstractTest {
         BuildResult buildResult = withGradleVersion(Versions.latestGradleVersion().version)
             .forwardOutput()
             .withProjectDir(temporaryFolder.root)
-            .withArguments("assemble", "--build-cache", "--stacktrace")
+            .withArguments("assemble", "testDebug", "--build-cache", "--stacktrace")
             .build()
 
         then:

--- a/src/test/groovy/org/gradle/android/SimpleAndroidApp.groovy
+++ b/src/test/groovy/org/gradle/android/SimpleAndroidApp.groovy
@@ -285,6 +285,13 @@ class SimpleAndroidApp {
                 }
             """.stripIndent()
 
+        file("${basedir}/src/test/java/${packageName.replaceAll('\\.', '/')}/JavaUserTest.java") << """
+                package ${packageName};
+
+                public class JavaUserTest {
+                }
+            """.stripIndent()
+
         file("${basedir}/src/main/java/${packageName.replaceAll('\\.', '/')}/JavaUserDao.java") << """
             package ${packageName};
 


### PR DESCRIPTION
Fixes the issue described in https://github.com/gradle/android-cache-fix-gradle-plugin/issues/135#issuecomment-770726740 where the Room workaround configuration is only partially be applied to the test compile tasks.  Configuration is now only applied to the main compile tasks.  Tests have been expanded to cover test tasks as well in order to catch these sorts of issues.