### PR TITLE
Improve the cache-fix plugin build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,8 +44,11 @@ dependencies {
     testRuntime 'org.objenesis:objenesis:3.1'
 }
 
-sourceCompatibility = "1.8"
-targetCompatibility = "1.8"
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(8)
+    }
+}
 
 def generatedResources = "$buildDir/generated-resources/main"
 
@@ -103,8 +106,4 @@ tasks.withType(Test).configureEach {
         maxRetries = 3
         maxFailures = 20
     }
-}
-
-if (!JavaVersion.current().java8) {
-    throw new RuntimeException("Java 8 is required to execute the build")
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,10 +1,11 @@
 import groovy.json.JsonBuilder
 
 plugins {
-    id "com.gradle.plugin-publish" version "0.12.0"
     id 'groovy'
     id 'java-gradle-plugin'
+    id 'maven-publish'
     id 'codenarc'
+    id "com.gradle.plugin-publish" version "0.12.0"
     id "org.gradle.test-retry" version "1.2.0"
 }
 
@@ -67,41 +68,36 @@ sourceSets {
     }
 }
 
-pluginBundle {
-    website = 'https://github.com/gradle/android-cache-fix-gradle-plugin'
-    vcsUrl = 'https://github.com/gradle/android-cache-fix-gradle-plugin'
-
-    description = 'Gradle plugin to fix Android caching problems'
-
+gradlePlugin {
     plugins {
         androidCacheFixPlugin {
             id = 'org.gradle.android.cache-fix'
             displayName = 'Gradle Android cache fix plugin'
-            tags = ['android', 'cache', 'fix']
-            version = project.version
+            description = 'Gradle plugin to fix Android caching problems'
+            implementationClass = 'org.gradle.android.AndroidCacheFixPlugin'
         }
     }
+}
+
+pluginBundle {
+    website = 'https://github.com/gradle/android-cache-fix-gradle-plugin'
+    vcsUrl = 'https://github.com/gradle/android-cache-fix-gradle-plugin'
+
+    tags = ['android', 'cache', 'fix']
 }
 
 def localRepo = file("$buildDir/local-repo")
 
-artifacts {
-    runtime jar
-}
-
-tasks.register('install', Upload) {
+publishing {
     repositories {
-        ivy {
+        maven {
             url = localRepo.toURI()
         }
     }
-    descriptorDestination = file("$buildDir/ivy/ivy.xml")
-    uploadDescriptor = true
-    configuration = configurations.runtime
 }
 
 tasks.withType(Test).configureEach {
-    dependsOn install
+    dependsOn publish
     systemProperty "local.repo", localRepo.toURI()
     retry {
         maxRetries = 3

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,3 @@
 systemProp.gradle.publish.skip.namespace.check=true
+
+org.gradle.caching=true

--- a/src/main/resources/META-INF/gradle-plugins/org.gradle.android.cache-fix.properties
+++ b/src/main/resources/META-INF/gradle-plugins/org.gradle.android.cache-fix.properties
@@ -1,1 +1,0 @@
-implementation-class=org.gradle.android.AndroidCacheFixPlugin

--- a/src/test/groovy/org/gradle/android/SimpleAndroidApp.groovy
+++ b/src/test/groovy/org/gradle/android/SimpleAndroidApp.groovy
@@ -48,7 +48,7 @@ class SimpleAndroidApp {
                     repositories {
                         google()
                         jcenter()
-                        ivy {
+                        maven {
                             url = "${System.getProperty("local.repo")}"
                         }
                     }


### PR DESCRIPTION
- Enable caching
- Enable parallel test execution
- Use `maven-publish` instead of `Upload` task
- Use Java toolchains to compile with JDK8