### PR TITLE
Update to latest version of 7.0.0-alpha and 4.2.0-rc01

### DIFF
--- a/.github/workflows/ci-check.yml
+++ b/.github/workflows/ci-check.yml
@@ -63,6 +63,7 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
+      fail-fast: false
       matrix:
         androidTestTask: ${{ fromJson(needs.generate_versions.outputs.matrix) }}
 

--- a/build.gradle
+++ b/build.gradle
@@ -18,8 +18,8 @@ def isCI = (System.getenv('CI') ?: 'false').toBoolean()
 // Maps supported Android plugin versions to the versions of Gradle that support it
 def sevenDotZeroNightly = "7.0-rc-2"
 def supportedVersions = [
-    "7.0.0-alpha08": ["6.8.3", sevenDotZeroNightly],
-    "4.2.0-beta05": ["6.8.3", sevenDotZeroNightly],
+    "7.0.0-alpha12": ["6.8.3", sevenDotZeroNightly],
+    "4.2.0-rc01": ["6.8.3", sevenDotZeroNightly],
     "4.1.2": ["6.5.1", "6.8.3"],
     "4.0.2": ["6.1.1", "6.8.3"],
     "3.6.4": ["5.6.4", "6.8.3"],

--- a/src/main/groovy/org/gradle/android/AndroidCacheFixPlugin.groovy
+++ b/src/main/groovy/org/gradle/android/AndroidCacheFixPlugin.groovy
@@ -4,6 +4,7 @@ import com.android.builder.model.Version
 import com.google.common.collect.ImmutableList
 import groovy.transform.CompileStatic
 import org.gradle.android.workarounds.CompileLibraryResourcesWorkaround_4_0
+import org.gradle.android.workarounds.CompileLibraryResourcesWorkaround_7_0
 import org.gradle.android.workarounds.CompilerArgsProcessor
 import org.gradle.android.workarounds.MergeJavaResourcesWorkaround
 import org.gradle.android.workarounds.MergeNativeLibsWorkaround
@@ -30,7 +31,7 @@ class AndroidCacheFixPlugin implements Plugin<Project> {
     private static final Logger LOGGER = LoggerFactory.getLogger(AndroidCacheFixPlugin)
 
     static final String IGNORE_VERSION_CHECK_PROPERTY = "org.gradle.android.cache-fix.ignoreVersionCheck"
-    static final VersionNumber CURRENT_ANDROID_VERSION = android(Version.ANDROID_GRADLE_PLUGIN_VERSION)
+    public static final VersionNumber CURRENT_ANDROID_VERSION = android(Version.ANDROID_GRADLE_PLUGIN_VERSION)
 
     private final List<Workaround> workarounds = [] as List<Workaround>
 
@@ -56,6 +57,7 @@ class AndroidCacheFixPlugin implements Plugin<Project> {
                 new RoomSchemaLocationWorkaround(),
                 new CompileLibraryResourcesWorkaround_4_0(),
                 new CompileLibraryResourcesWorkaround_4_2(),
+                new CompileLibraryResourcesWorkaround_7_0(),
                 new MergeResourcesWorkaround(),
                 new StripDebugSymbolsWorkaround()
             )

--- a/src/main/groovy/org/gradle/android/workarounds/AbstractCompileLibraryResourcesWorkaround_4_2_orHigher.groovy
+++ b/src/main/groovy/org/gradle/android/workarounds/AbstractCompileLibraryResourcesWorkaround_4_2_orHigher.groovy
@@ -1,0 +1,56 @@
+package org.gradle.android.workarounds
+
+import org.gradle.api.Project
+import org.gradle.api.Task
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.tasks.PathSensitivity
+
+import java.lang.reflect.Field
+
+
+abstract class AbstractCompileLibraryResourcesWorkaround_4_2_orHigher implements Workaround {
+
+    abstract String getPropertyName();
+
+    // This task is new in AGP 4.0.0 so use Class.forName to allow for backward compatibility with older AGP versions.
+    static Class<?> getAndroidTaskClass() {
+        return Class.forName('com.android.build.gradle.tasks.CompileLibraryResourcesTask')
+    }
+
+    protected void setPropertyValue(Task task, ConfigurableFileCollection directoryProperty) {
+        Field field = task.class.getDeclaredFields().find { it.name == "__${propertyName}__" }
+        field.setAccessible(true)
+        field.set(task, directoryProperty)
+    }
+
+    @Override
+    void apply(WorkaroundContext context) {
+        Project project = context.project
+        project.tasks.withType(androidTaskClass).configureEach { Task task ->
+            ConfigurableFileCollection originalPropertyValue = project.files()
+            // Create a synthetic input with the original property value and RELATIVE path sensitivity
+            task.inputs.files(originalPropertyValue)
+                .withPathSensitivity(PathSensitivity.RELATIVE)
+                .withPropertyName("${propertyName}.workaround")
+                .optional()
+            project.gradle.taskGraph.whenReady {
+                originalPropertyValue.from(task.getProperty(propertyName))
+                def dummyProperty = project.objects.fileCollection()
+                // Non-existent file to give the ConfigurableFileCollection a value.
+                dummyProperty.setFrom(project.file('/doesnt-exist'))
+                setPropertyValue(task, dummyProperty)
+
+                // Set the task property back to its original value
+                task.doFirst {
+                    setPropertyValue(it, originalPropertyValue)
+                }
+
+            }
+        }
+    }
+
+    @Override
+    boolean canBeApplied(Project project) {
+        return true
+    }
+}

--- a/src/main/groovy/org/gradle/android/workarounds/CompileLibraryResourcesWorkaround_7_0.groovy
+++ b/src/main/groovy/org/gradle/android/workarounds/CompileLibraryResourcesWorkaround_7_0.groovy
@@ -8,11 +8,10 @@ import org.gradle.android.AndroidIssue
  * This is the same as the {@link CompileLibraryResourcesWorkaround_4_0} but the field was renamed with a new type
  * in 4.2.0-alpha09.
  */
-@AndroidIssue(introducedIn = "4.2.0-alpha09", fixedIn = ['7.0.0-alpha09'], link = "https://issuetracker.google.com/issues/155218379")
-class CompileLibraryResourcesWorkaround_4_2 extends AbstractCompileLibraryResourcesWorkaround_4_2_orHigher {
+@AndroidIssue(introducedIn = "7.0.0-alpha09", fixedIn = [], link = "https://issuetracker.google.com/issues/155218379")
+class CompileLibraryResourcesWorkaround_7_0 extends AbstractCompileLibraryResourcesWorkaround_4_2_orHigher {
     @Override
     String getPropertyName() {
-        return "inputDirectories"
+        return "inputDirectoriesAsAbsolute"
     }
 }
-

--- a/src/main/groovy/org/gradle/android/workarounds/MergeResourcesWorkaround.groovy
+++ b/src/main/groovy/org/gradle/android/workarounds/MergeResourcesWorkaround.groovy
@@ -11,8 +11,11 @@ import org.gradle.api.tasks.PathSensitivity
 /**
  * Fixes the cacheability issue with MergeResources Task where the rawLocalResources field is treated as an input with
  * absolute path sensitivity.
+ *
+ * This is marked as "fixedIn" AGP 7.0.0-alpha09, but the issue has not been fixed.  That version introduced changes
+ * that prevent us from working around the issue anymore, so we can no longer apply it.
  */
-@AndroidIssue(introducedIn = "4.0.0", fixedIn = [], link = "https://issuetracker.google.com/issues/141301405")
+@AndroidIssue(introducedIn = "4.0.0", fixedIn = ['7.0.0-alpha09'], link = "https://issuetracker.google.com/issues/141301405")
 class MergeResourcesWorkaround implements Workaround {
     // This task is new in AGP 4.0.0 so use Class.forName to allow for backward compatibility with older AGP versions.
     static Class<?> getAndroidTaskClass() {

--- a/src/test/groovy/org/gradle/android/CrossVersionOutcomeAndRelocationTest.groovy
+++ b/src/test/groovy/org/gradle/android/CrossVersionOutcomeAndRelocationTest.groovy
@@ -140,7 +140,6 @@ class CrossVersionOutcomeAndRelocationTest extends AbstractTest {
         def isAndroid35xTo41x = androidVersion >= android("3.5.0") && androidVersion <= android("4.2.0-alpha01")
         def isAndroid35xTo42x = androidVersion >= android("3.5.0") && androidVersion <= android("7.0.0-alpha01")
         def isAndroid36xOrHigher = androidVersion >= android("3.6.0")
-        def isAndroid36xTo42x = androidVersion >= android("3.6.0") && androidVersion <= android("7.0.0-alpha01")
         def isAndroid40xOrHigher = androidVersion >= android("4.0.0-beta01")
         def isAndroid40x = androidVersion >= android("4.0.0") && androidVersion < android("4.1.0-alpha01")
         def isAndroid40xTo41x = androidVersion >= android("4.0.0") && androidVersion <= android("4.2.0-alpha01")
@@ -180,11 +179,6 @@ class CrossVersionOutcomeAndRelocationTest extends AbstractTest {
         // Applies to 3.5.x, 3.6.x, 4.0.x, 4.1.x and 4.2.x
         if (isAndroid35xTo42x) {
             android35xTo42xExpectations(builder)
-        }
-
-        // Applies to 3.6.x, 4.0.x, 4.1.x, and 4.2.x
-        if (isAndroid36xTo42x) {
-            android36xTo42xOnlyExpectations(builder)
         }
 
         // Applies to anything 3.6.0 or higher
@@ -292,8 +286,6 @@ class CrossVersionOutcomeAndRelocationTest extends AbstractTest {
         builder.expect(':app:processDebugManifest', FROM_CACHE)
         builder.expect(':app:processReleaseJavaRes', NO_SOURCE)
         builder.expect(':app:processReleaseManifest', FROM_CACHE)
-        builder.expect(':app:stripDebugDebugSymbols', NO_SOURCE)
-        builder.expect(':app:stripReleaseDebugSymbols', NO_SOURCE)
         builder.expect(':app:validateSigningDebug', FROM_CACHE)
         builder.expect(':library:assemble', SUCCESS)
         builder.expect(':library:assembleDebug', SUCCESS)
@@ -352,8 +344,6 @@ class CrossVersionOutcomeAndRelocationTest extends AbstractTest {
         builder.expect(':library:processDebugManifest', FROM_CACHE)
         builder.expect(':library:processReleaseJavaRes', NO_SOURCE)
         builder.expect(':library:processReleaseManifest', FROM_CACHE)
-        builder.expect(':library:stripDebugDebugSymbols', NO_SOURCE)
-        builder.expect(':library:stripReleaseDebugSymbols', NO_SOURCE)
 
         // the outcome of this task is not consistent with the kotlin plugin applied
         builder.expectChangingValue(':library:verifyReleaseResources')
@@ -368,6 +358,8 @@ class CrossVersionOutcomeAndRelocationTest extends AbstractTest {
         builder.expect(':app:dataBindingMergeGenClassesRelease', SUCCESS)
         builder.expect(':app:mainApkListPersistenceDebug', FROM_CACHE)
         builder.expect(':app:mainApkListPersistenceRelease', FROM_CACHE)
+        builder.expect(':app:stripDebugDebugSymbols', SUCCESS)
+        builder.expect(':app:stripReleaseDebugSymbols', SUCCESS)
         builder.expect(':library:bundleLibCompileDebug', SUCCESS)
         builder.expect(':library:bundleLibCompileRelease', SUCCESS)
         builder.expect(':library:bundleLibResDebug', SUCCESS)
@@ -384,6 +376,8 @@ class CrossVersionOutcomeAndRelocationTest extends AbstractTest {
         builder.expect(':library:mergeDebugGeneratedProguardFiles', SUCCESS)
         builder.expect(':library:mergeReleaseConsumerProguardFiles', SUCCESS)
         builder.expect(':library:mergeReleaseGeneratedProguardFiles', SUCCESS)
+        builder.expect(':library:stripDebugDebugSymbols', SUCCESS)
+        builder.expect(':library:stripReleaseDebugSymbols', SUCCESS)
     }
 
     static void android35xTo40xExpectations(ExpectedOutcomeBuilder builder) {
@@ -396,6 +390,8 @@ class CrossVersionOutcomeAndRelocationTest extends AbstractTest {
         builder.expect(':library:generateReleaseSources', SUCCESS)
         builder.expect(':library:prepareLintJar', SUCCESS)
         builder.expect(':app:prepareLintJar', SUCCESS)
+        builder.expect(':library:mergeDebugNativeLibs', SUCCESS)
+        builder.expect(':library:mergeReleaseNativeLibs', SUCCESS)
     }
 
     static void android35xTo41xExpectations(ExpectedOutcomeBuilder builder) {
@@ -410,21 +406,19 @@ class CrossVersionOutcomeAndRelocationTest extends AbstractTest {
         builder.expect(':app:mergeReleaseResources', FROM_CACHE)
         builder.expect(':app:processDebugResources', FROM_CACHE)
         builder.expect(':app:processReleaseResources', FROM_CACHE)
+        builder.expect(':app:mergeDebugNativeLibs', SUCCESS)
+        builder.expect(':app:mergeReleaseNativeLibs', SUCCESS)
     }
 
     static void android35xOnlyExpectations(ExpectedOutcomeBuilder builder) {
         builder.expect(':app:checkDebugManifest', SUCCESS)
         builder.expect(':app:checkReleaseManifest', SUCCESS)
-        builder.expect(':app:mergeDebugNativeLibs', SUCCESS)
-        builder.expect(':app:mergeReleaseNativeLibs', SUCCESS)
         builder.expect(':app:signingConfigWriterDebug', FROM_CACHE)
         builder.expect(':app:signingConfigWriterRelease', FROM_CACHE)
         builder.expect(':app:transformClassesWithDexBuilderForDebug', SUCCESS)
         builder.expect(':app:transformClassesWithDexBuilderForRelease', SUCCESS)
         builder.expect(':library:checkDebugManifest', SUCCESS)
         builder.expect(':library:checkReleaseManifest', SUCCESS)
-        builder.expect(':library:mergeDebugNativeLibs', SUCCESS)
-        builder.expect(':library:mergeReleaseNativeLibs', SUCCESS)
         builder.expect(':library:parseDebugLibraryResources', FROM_CACHE)
         builder.expect(':library:parseReleaseLibraryResources', FROM_CACHE)
         builder.expect(':library:transformClassesAndResourcesWithSyncLibJarsForDebug', SUCCESS)
@@ -451,8 +445,6 @@ class CrossVersionOutcomeAndRelocationTest extends AbstractTest {
         builder.expect(':library:copyReleaseJniLibsProjectOnly', FROM_CACHE)
         builder.expect(':library:extractDeepLinksDebug', FROM_CACHE)
         builder.expect(':library:extractDeepLinksRelease', FROM_CACHE)
-        builder.expect(':library:mergeDebugNativeLibs', NO_SOURCE)
-        builder.expect(':library:mergeReleaseNativeLibs', NO_SOURCE)
         builder.expect(':library:parseDebugLocalResources', FROM_CACHE)
         builder.expect(':library:parseReleaseLocalResources', FROM_CACHE)
         builder.expect(':library:syncDebugLibJars', FROM_CACHE)
@@ -461,16 +453,13 @@ class CrossVersionOutcomeAndRelocationTest extends AbstractTest {
         builder.expect(':library:compileReleaseLibraryResources', FROM_CACHE)
     }
 
-    static void android36xTo42xOnlyExpectations(ExpectedOutcomeBuilder builder) {
-        builder.expect(':app:mergeDebugNativeLibs', SUCCESS)
-        builder.expect(':app:mergeReleaseNativeLibs', SUCCESS)
-    }
-
     static void android40xOrHigherExpectations(ExpectedOutcomeBuilder builder) {
         builder.expect(':app:compileDebugShaders', NO_SOURCE)
         builder.expect(':app:compileReleaseShaders', NO_SOURCE)
         builder.expect(':app:dataBindingMergeGenClassesDebug', FROM_CACHE)
         builder.expect(':app:dataBindingMergeGenClassesRelease', FROM_CACHE)
+        builder.expect(':app:stripDebugDebugSymbols', NO_SOURCE)
+        builder.expect(':app:stripReleaseDebugSymbols', NO_SOURCE)
         builder.expect(':library:compileDebugShaders', NO_SOURCE)
         builder.expect(':library:compileReleaseShaders', NO_SOURCE)
         builder.expect(':library:dataBindingMergeGenClassesDebug', FROM_CACHE)
@@ -483,6 +472,8 @@ class CrossVersionOutcomeAndRelocationTest extends AbstractTest {
         builder.expect(':library:bundleLibResDebug', NO_SOURCE)
         builder.expect(':library:bundleLibResRelease', NO_SOURCE)
         builder.expect(':library:bundleLibCompileToJarRelease', FROM_CACHE)
+        builder.expect(':library:stripDebugDebugSymbols', NO_SOURCE)
+        builder.expect(':library:stripReleaseDebugSymbols', NO_SOURCE)
         builder.expect(':app:collectReleaseDependencies', SUCCESS)
         builder.expect(':app:sdkReleaseDependencyData', SUCCESS)
     }
@@ -508,6 +499,8 @@ class CrossVersionOutcomeAndRelocationTest extends AbstractTest {
         builder.expect(':app:checkReleaseAarMetadata', FROM_CACHE)
         builder.expect(':library:writeDebugAarMetadata', FROM_CACHE)
         builder.expect(':library:writeReleaseAarMetadata', FROM_CACHE)
+        builder.expect(':library:mergeDebugNativeLibs', NO_SOURCE)
+        builder.expect(':library:mergeReleaseNativeLibs', NO_SOURCE)
     }
 
     static void android41xOnlyExpectations(ExpectedOutcomeBuilder builder) {

--- a/src/test/groovy/org/gradle/android/CrossVersionOutcomeAndRelocationTest.groovy
+++ b/src/test/groovy/org/gradle/android/CrossVersionOutcomeAndRelocationTest.groovy
@@ -138,7 +138,9 @@ class CrossVersionOutcomeAndRelocationTest extends AbstractTest {
         def isAndroid35xTo36x = androidVersion >= android("3.5.0") && androidVersion <= android("3.6.4")
         def isAndroid35xTo40x = androidVersion >= android("3.5.0") && androidVersion <= android("4.1.0-alpha01")
         def isAndroid35xTo41x = androidVersion >= android("3.5.0") && androidVersion <= android("4.2.0-alpha01")
+        def isAndroid35xTo42x = androidVersion >= android("3.5.0") && androidVersion <= android("7.0.0-alpha01")
         def isAndroid36xOrHigher = androidVersion >= android("3.6.0")
+        def isAndroid36xTo42x = androidVersion >= android("3.6.0") && androidVersion <= android("7.0.0-alpha01")
         def isAndroid40xOrHigher = androidVersion >= android("4.0.0-beta01")
         def isAndroid40x = androidVersion >= android("4.0.0") && androidVersion < android("4.1.0-alpha01")
         def isAndroid40xTo41x = androidVersion >= android("4.0.0") && androidVersion <= android("4.2.0-alpha01")
@@ -147,6 +149,7 @@ class CrossVersionOutcomeAndRelocationTest extends AbstractTest {
         def isAndroid42x = androidVersion >= android("4.2.0-alpha01") && androidVersion < android("7.0.0-alpha01")
         def isAndroid42xOrHigher = androidVersion >= android("4.2.0-alpha01")
         def isAndroid70xOrHigher = androidVersion >= android("7.0.0-alpha01")
+
         def builder = new ExpectedOutcomeBuilder()
 
         // Applies to anything 3.5.0 or higher
@@ -172,6 +175,16 @@ class CrossVersionOutcomeAndRelocationTest extends AbstractTest {
         // Applies to 3.5.x, 3.6.x, 4.0.x and 4.1.x
         if (isAndroid35xTo41x) {
             android35xTo41xExpectations(builder)
+        }
+
+        // Applies to 3.5.x, 3.6.x, 4.0.x, 4.1.x and 4.2.x
+        if (isAndroid35xTo42x) {
+            android35xTo42xExpectations(builder)
+        }
+
+        // Applies to 3.6.x, 4.0.x, 4.1.x, and 4.2.x
+        if (isAndroid36xTo42x) {
+            android36xTo42xOnlyExpectations(builder)
         }
 
         // Applies to anything 3.6.0 or higher
@@ -214,7 +227,7 @@ class CrossVersionOutcomeAndRelocationTest extends AbstractTest {
         }
 
         if (isAndroid70xOrHigher) {
-            android70xOrHIgherExpectations(builder)
+            android70xOrHigherExpectations(builder)
         }
 
         new ExpectedResults(
@@ -256,10 +269,6 @@ class CrossVersionOutcomeAndRelocationTest extends AbstractTest {
         builder.expect(':app:kaptDebugKotlin', FROM_CACHE)
         builder.expect(':app:kaptGenerateStubsReleaseKotlin', FROM_CACHE)
         builder.expect(':app:kaptReleaseKotlin', FROM_CACHE)
-        builder.expect(':app:mergeDebugResources', FROM_CACHE)
-        builder.expect(':app:mergeReleaseResources', FROM_CACHE)
-        builder.expect(':app:processDebugResources', FROM_CACHE)
-        builder.expect(':app:processReleaseResources', FROM_CACHE)
         builder.expect(':app:mergeDebugAssets', FROM_CACHE)
         builder.expect(':app:mergeDebugJavaResource', SUCCESS)
         builder.expect(':app:mergeDebugJniLibFolders', FROM_CACHE)
@@ -283,8 +292,6 @@ class CrossVersionOutcomeAndRelocationTest extends AbstractTest {
         builder.expect(':app:processDebugManifest', FROM_CACHE)
         builder.expect(':app:processReleaseJavaRes', NO_SOURCE)
         builder.expect(':app:processReleaseManifest', FROM_CACHE)
-        builder.expect(':app:stripDebugDebugSymbols', SUCCESS)
-        builder.expect(':app:stripReleaseDebugSymbols', SUCCESS)
         builder.expect(':app:validateSigningDebug', FROM_CACHE)
         builder.expect(':library:assemble', SUCCESS)
         builder.expect(':library:assembleDebug', SUCCESS)
@@ -343,8 +350,6 @@ class CrossVersionOutcomeAndRelocationTest extends AbstractTest {
         builder.expect(':library:processDebugManifest', FROM_CACHE)
         builder.expect(':library:processReleaseJavaRes', NO_SOURCE)
         builder.expect(':library:processReleaseManifest', FROM_CACHE)
-        builder.expect(':library:stripDebugDebugSymbols', SUCCESS)
-        builder.expect(':library:stripReleaseDebugSymbols', SUCCESS)
 
         // the outcome of this task is not consistent with the kotlin plugin applied
         builder.expectChangingValue(':library:verifyReleaseResources')
@@ -396,6 +401,16 @@ class CrossVersionOutcomeAndRelocationTest extends AbstractTest {
         builder.expect(':library:javaPreCompileRelease', FROM_CACHE)
     }
 
+    static void android35xTo42xExpectations(ExpectedOutcomeBuilder builder) {
+        builder.expect(':app:stripDebugDebugSymbols', SUCCESS)
+        builder.expect(':app:stripReleaseDebugSymbols', SUCCESS)
+        builder.expect(':library:stripDebugDebugSymbols', SUCCESS)
+        builder.expect(':library:stripReleaseDebugSymbols', SUCCESS)
+        builder.expect(':app:mergeDebugResources', FROM_CACHE)
+        builder.expect(':app:mergeReleaseResources', FROM_CACHE)
+        builder.expect(':app:processDebugResources', FROM_CACHE)
+        builder.expect(':app:processReleaseResources', FROM_CACHE)
+    }
 
     static void android35xOnlyExpectations(ExpectedOutcomeBuilder builder) {
         builder.expect(':app:checkDebugManifest', SUCCESS)
@@ -430,22 +445,25 @@ class CrossVersionOutcomeAndRelocationTest extends AbstractTest {
         builder.expect(':app:dexBuilderRelease', FROM_CACHE)
         builder.expect(':app:extractDeepLinksDebug', FROM_CACHE)
         builder.expect(':app:extractDeepLinksRelease', FROM_CACHE)
-        builder.expect(':app:mergeDebugNativeLibs', SUCCESS)
-        builder.expect(':app:mergeReleaseNativeLibs', SUCCESS)
         builder.expect(':library:copyDebugJniLibsProjectAndLocalJars', FROM_CACHE)
         builder.expect(':library:copyDebugJniLibsProjectOnly', FROM_CACHE)
         builder.expect(':library:copyReleaseJniLibsProjectAndLocalJars', FROM_CACHE)
         builder.expect(':library:copyReleaseJniLibsProjectOnly', FROM_CACHE)
         builder.expect(':library:extractDeepLinksDebug', FROM_CACHE)
         builder.expect(':library:extractDeepLinksRelease', FROM_CACHE)
-        builder.expect(':library:mergeDebugNativeLibs', SUCCESS)
-        builder.expect(':library:mergeReleaseNativeLibs', SUCCESS)
         builder.expect(':library:parseDebugLocalResources', FROM_CACHE)
         builder.expect(':library:parseReleaseLocalResources', FROM_CACHE)
         builder.expect(':library:syncDebugLibJars', FROM_CACHE)
         builder.expect(':library:syncReleaseLibJars', FROM_CACHE)
         builder.expect(':library:compileDebugLibraryResources', FROM_CACHE)
         builder.expect(':library:compileReleaseLibraryResources', FROM_CACHE)
+    }
+
+    static void android36xTo42xOnlyExpectations(ExpectedOutcomeBuilder builder) {
+        builder.expect(':app:mergeDebugNativeLibs', SUCCESS)
+        builder.expect(':app:mergeReleaseNativeLibs', SUCCESS)
+        builder.expect(':library:mergeDebugNativeLibs', SUCCESS)
+        builder.expect(':library:mergeReleaseNativeLibs', SUCCESS)
     }
 
     static void android40xOrHigherExpectations(ExpectedOutcomeBuilder builder) {
@@ -509,6 +527,7 @@ class CrossVersionOutcomeAndRelocationTest extends AbstractTest {
         // New non-cacheable tasks in 4.2.0-alpha10:
         builder.expect(':app:writeReleaseApplicationId', SUCCESS)
         builder.expect(':app:analyticsRecordingRelease', SUCCESS)
+        builder.expect(':app:extractReleaseNativeSymbolTables', FROM_CACHE)
     }
 
     static void android42xOrHigherExpectations(ExpectedOutcomeBuilder builder) {
@@ -518,14 +537,26 @@ class CrossVersionOutcomeAndRelocationTest extends AbstractTest {
         builder.expect(':app:optimizeReleaseResources', FROM_CACHE)
         builder.expect(':app:mergeReleaseNativeDebugMetadata', NO_SOURCE)
         builder.expect(':app:writeDebugAppMetadata', FROM_CACHE)
-        builder.expect(':app:extractReleaseNativeSymbolTables', FROM_CACHE)
         builder.expect(':app:writeReleaseAppMetadata', FROM_CACHE)
         builder.expect(':app:writeDebugSigningConfigVersions', FROM_CACHE)
         builder.expect(':app:writeReleaseSigningConfigVersions', FROM_CACHE)
     }
 
-    static void android70xOrHIgherExpectations(ExpectedOutcomeBuilder builder) {
+    static void android70xOrHigherExpectations(ExpectedOutcomeBuilder builder) {
         builder.expect(':app:desugarDebugFileDependencies', FROM_CACHE)
         builder.expect(':app:desugarReleaseFileDependencies', FROM_CACHE)
+        builder.expect(':app:extractReleaseNativeSymbolTables', NO_SOURCE)
+        builder.expect(':app:mergeDebugNativeLibs', NO_SOURCE)
+        builder.expect(':app:mergeReleaseNativeLibs', NO_SOURCE)
+        builder.expect(':library:mergeDebugNativeLibs', NO_SOURCE)
+        builder.expect(':library:mergeReleaseNativeLibs', NO_SOURCE)
+        builder.expect(':app:stripDebugDebugSymbols', NO_SOURCE)
+        builder.expect(':app:stripReleaseDebugSymbols', NO_SOURCE)
+        builder.expect(':library:stripDebugDebugSymbols', NO_SOURCE)
+        builder.expect(':library:stripReleaseDebugSymbols', NO_SOURCE)
+        builder.expect(':app:mergeDebugResources', SUCCESS)
+        builder.expect(':app:mergeReleaseResources', SUCCESS)
+        builder.expect(':app:processDebugResources', SUCCESS)
+        builder.expect(':app:processReleaseResources', SUCCESS)
     }
 }

--- a/src/test/groovy/org/gradle/android/CrossVersionOutcomeAndRelocationTest.groovy
+++ b/src/test/groovy/org/gradle/android/CrossVersionOutcomeAndRelocationTest.groovy
@@ -292,6 +292,8 @@ class CrossVersionOutcomeAndRelocationTest extends AbstractTest {
         builder.expect(':app:processDebugManifest', FROM_CACHE)
         builder.expect(':app:processReleaseJavaRes', NO_SOURCE)
         builder.expect(':app:processReleaseManifest', FROM_CACHE)
+        builder.expect(':app:stripDebugDebugSymbols', NO_SOURCE)
+        builder.expect(':app:stripReleaseDebugSymbols', NO_SOURCE)
         builder.expect(':app:validateSigningDebug', FROM_CACHE)
         builder.expect(':library:assemble', SUCCESS)
         builder.expect(':library:assembleDebug', SUCCESS)
@@ -350,6 +352,8 @@ class CrossVersionOutcomeAndRelocationTest extends AbstractTest {
         builder.expect(':library:processDebugManifest', FROM_CACHE)
         builder.expect(':library:processReleaseJavaRes', NO_SOURCE)
         builder.expect(':library:processReleaseManifest', FROM_CACHE)
+        builder.expect(':library:stripDebugDebugSymbols', NO_SOURCE)
+        builder.expect(':library:stripReleaseDebugSymbols', NO_SOURCE)
 
         // the outcome of this task is not consistent with the kotlin plugin applied
         builder.expectChangingValue(':library:verifyReleaseResources')
@@ -402,10 +406,6 @@ class CrossVersionOutcomeAndRelocationTest extends AbstractTest {
     }
 
     static void android35xTo42xExpectations(ExpectedOutcomeBuilder builder) {
-        builder.expect(':app:stripDebugDebugSymbols', SUCCESS)
-        builder.expect(':app:stripReleaseDebugSymbols', SUCCESS)
-        builder.expect(':library:stripDebugDebugSymbols', SUCCESS)
-        builder.expect(':library:stripReleaseDebugSymbols', SUCCESS)
         builder.expect(':app:mergeDebugResources', FROM_CACHE)
         builder.expect(':app:mergeReleaseResources', FROM_CACHE)
         builder.expect(':app:processDebugResources', FROM_CACHE)
@@ -451,6 +451,8 @@ class CrossVersionOutcomeAndRelocationTest extends AbstractTest {
         builder.expect(':library:copyReleaseJniLibsProjectOnly', FROM_CACHE)
         builder.expect(':library:extractDeepLinksDebug', FROM_CACHE)
         builder.expect(':library:extractDeepLinksRelease', FROM_CACHE)
+        builder.expect(':library:mergeDebugNativeLibs', NO_SOURCE)
+        builder.expect(':library:mergeReleaseNativeLibs', NO_SOURCE)
         builder.expect(':library:parseDebugLocalResources', FROM_CACHE)
         builder.expect(':library:parseReleaseLocalResources', FROM_CACHE)
         builder.expect(':library:syncDebugLibJars', FROM_CACHE)
@@ -462,8 +464,6 @@ class CrossVersionOutcomeAndRelocationTest extends AbstractTest {
     static void android36xTo42xOnlyExpectations(ExpectedOutcomeBuilder builder) {
         builder.expect(':app:mergeDebugNativeLibs', SUCCESS)
         builder.expect(':app:mergeReleaseNativeLibs', SUCCESS)
-        builder.expect(':library:mergeDebugNativeLibs', SUCCESS)
-        builder.expect(':library:mergeReleaseNativeLibs', SUCCESS)
     }
 
     static void android40xOrHigherExpectations(ExpectedOutcomeBuilder builder) {
@@ -527,7 +527,7 @@ class CrossVersionOutcomeAndRelocationTest extends AbstractTest {
         // New non-cacheable tasks in 4.2.0-alpha10:
         builder.expect(':app:writeReleaseApplicationId', SUCCESS)
         builder.expect(':app:analyticsRecordingRelease', SUCCESS)
-        builder.expect(':app:extractReleaseNativeSymbolTables', FROM_CACHE)
+        builder.expect(':app:extractReleaseNativeSymbolTables', NO_SOURCE)
     }
 
     static void android42xOrHigherExpectations(ExpectedOutcomeBuilder builder) {
@@ -548,12 +548,6 @@ class CrossVersionOutcomeAndRelocationTest extends AbstractTest {
         builder.expect(':app:extractReleaseNativeSymbolTables', NO_SOURCE)
         builder.expect(':app:mergeDebugNativeLibs', NO_SOURCE)
         builder.expect(':app:mergeReleaseNativeLibs', NO_SOURCE)
-        builder.expect(':library:mergeDebugNativeLibs', NO_SOURCE)
-        builder.expect(':library:mergeReleaseNativeLibs', NO_SOURCE)
-        builder.expect(':app:stripDebugDebugSymbols', NO_SOURCE)
-        builder.expect(':app:stripReleaseDebugSymbols', NO_SOURCE)
-        builder.expect(':library:stripDebugDebugSymbols', NO_SOURCE)
-        builder.expect(':library:stripReleaseDebugSymbols', NO_SOURCE)
         builder.expect(':app:mergeDebugResources', SUCCESS)
         builder.expect(':app:mergeReleaseResources', SUCCESS)
         builder.expect(':app:processDebugResources', SUCCESS)

--- a/src/test/groovy/org/gradle/android/SimpleAndroidApp.groovy
+++ b/src/test/groovy/org/gradle/android/SimpleAndroidApp.groovy
@@ -225,8 +225,8 @@ class SimpleAndroidApp {
      * support) and we provide a dummy library for the downstream task to "merge".  This reliably triggers the
      * cache relocation problem on all android versions.
      */
-    private static String getRenderscriptConfiguration() {
-        return '''
+    private String getRenderscriptConfiguration() {
+        return androidVersion >= VersionNumber.parse('7.0.0-alpha12') ? '' : '''
             android {
                 defaultConfig {
                     renderscriptTargetApi 18

--- a/src/test/groovy/org/gradle/android/WorkaroundTest.groovy
+++ b/src/test/groovy/org/gradle/android/WorkaroundTest.groovy
@@ -12,8 +12,8 @@ class WorkaroundTest extends Specification {
         workarounds.collect { it.class.simpleName.replaceAll(/Workaround/, "") }.sort() == expectedWorkarounds.sort()
         where:
         androidVersion  | expectedWorkarounds
-        "7.0.0-alpha01" | ['MergeJavaResources', 'RoomSchemaLocation', 'StripDebugSymbols', 'MergeNativeLibs', 'CompileLibraryResources_4_2', 'MergeResources']
-        "4.2.0-beta05"  | ['MergeJavaResources', 'RoomSchemaLocation', 'StripDebugSymbols', 'MergeNativeLibs', 'CompileLibraryResources_4_2', 'MergeResources']
+        "7.0.0-alpha12" | ['MergeJavaResources', 'RoomSchemaLocation', 'StripDebugSymbols', 'MergeNativeLibs', 'CompileLibraryResources_7_0']
+        "4.2.0-rc01"    | ['MergeJavaResources', 'RoomSchemaLocation', 'StripDebugSymbols', 'MergeNativeLibs', 'CompileLibraryResources_4_2', 'MergeResources']
         "4.1.2"         | ['MergeJavaResources', 'RoomSchemaLocation', 'StripDebugSymbols', 'MergeNativeLibs', 'CompileLibraryResources_4_0', 'MergeResources']
         "4.0.2"         | ['MergeJavaResources', 'RoomSchemaLocation', 'StripDebugSymbols', 'MergeNativeLibs', 'CompileLibraryResources_4_0', 'MergeResources']
         "3.6.4"         | ['MergeJavaResources', 'RoomSchemaLocation', 'StripDebugSymbols', 'MergeNativeLibs']


### PR DESCRIPTION
Three changes here:

- 7.0.0 breaks the MergeResources workaround.  The property we manipulate to make it use absolute path sensitivity is now made immutable once the task graph has been calculated.  This means that although we can zero out the existing input before fingerprinting starts, we can't set it back to its original value after fingerprinting is finished.  I don't see a way around this, so I think we'll just need to wait for a fix to the underlying issue.
- The `inputDirectories` property for `CompileLibraryResourcesTask` has been renamed again in 7.0.0.  Luckily, its type did not change, so we can just subclass the 4.0 version of the workaround with the only difference being the name of the property.
- In 7.0.0, the hack that was in place to force `MergeNativeLibs` to execute no longer works because the property it sets is no longer mutable at execution time.  Since we have changed this workaround to _not_ do any caching any more, it's not as important that the task execute, so I've just removed this hack (which was super questionable in the first place).  This resulted in some differing task outcomes across the various versions (sometimes SUCCESS, sometimes NO_SOURCE). 