### PR TITLE
Test latest kotlin version and oldest supported.

### DIFF
--- a/src/test/groovy/org/gradle/android/ConfigurationCachingTest.groovy
+++ b/src/test/groovy/org/gradle/android/ConfigurationCachingTest.groovy
@@ -6,7 +6,7 @@ import org.junit.Assume
 
 @MultiVersionTest
 class ConfigurationCachingTest extends AbstractTest {
-    private static final VersionNumber SUPPORTED_KOTLIN_VERSION = VersionNumber.parse("1.4.30")
+    private static final VersionNumber SUPPORTED_KOTLIN_VERSION = TestVersions.latestSupportedKotlinVersion()
 
     def "plugin is compatible with configuration cache"() {
         Assume.assumeTrue(TestVersions.latestAndroidVersionForCurrentJDK() >= VersionNumber.parse("4.2.0-alpha01"))

--- a/src/test/groovy/org/gradle/android/CrossVersionOutcomeAndRelocationTest.groovy
+++ b/src/test/groovy/org/gradle/android/CrossVersionOutcomeAndRelocationTest.groovy
@@ -7,6 +7,7 @@ import org.gradle.util.GradleVersion
 import org.gradle.util.VersionNumber
 import spock.lang.Unroll
 
+import static org.gradle.android.TestVersions.latestKotlinVersionForGradleVersion
 import static org.gradle.android.Versions.android
 import static org.gradle.testkit.runner.TaskOutcome.FROM_CACHE
 import static org.gradle.testkit.runner.TaskOutcome.NO_SOURCE
@@ -27,12 +28,14 @@ class CrossVersionOutcomeAndRelocationTest extends AbstractTest {
         def originalDir = temporaryFolder.newFolder()
         SimpleAndroidApp.builder(originalDir, cacheDir)
             .withAndroidVersion(androidVersion)
+            .withKotlinVersion(latestKotlinVersionForGradleVersion(gradleVersion))
             .build()
             .writeProject()
 
         def relocatedDir = temporaryFolder.newFolder()
         SimpleAndroidApp.builder(relocatedDir, cacheDir)
             .withAndroidVersion(androidVersion)
+            .withKotlinVersion(latestKotlinVersionForGradleVersion(gradleVersion))
             .build()
             .writeProject()
 

--- a/src/test/groovy/org/gradle/android/RoomSchemaLocationWorkaroundTest.groovy
+++ b/src/test/groovy/org/gradle/android/RoomSchemaLocationWorkaroundTest.groovy
@@ -17,9 +17,10 @@ class RoomSchemaLocationWorkaroundTest extends AbstractTest {
     private static final List<String> ALL_VARIANTS = ["debug", "release"]
 
     @Unroll
-    def "schemas are generated into task-specific directory and are cacheable with kotlin and kapt workers enabled (Android #androidVersion)"() {
+    def "schemas are generated into task-specific directory and are cacheable with kotlin and kapt workers enabled (Android #androidVersion) (Kotlin #kotlinVersion)"() {
         SimpleAndroidApp.builder(temporaryFolder.root, cacheDir)
             .withAndroidVersion(androidVersion)
+            .withKotlinVersion(VersionNumber.parse(kotlinVersion))
             .build()
             .writeProject()
 
@@ -73,13 +74,15 @@ class RoomSchemaLocationWorkaroundTest extends AbstractTest {
         assertMergedSchemaOutputsExist()
 
         where:
-        androidVersion << TestVersions.latestAndroidVersions
+        //noinspection GroovyAssignabilityCheck
+        [androidVersion, kotlinVersion] << [TestVersions.latestAndroidVersions, TestVersions.supportedKotlinVersions].combinations()
     }
 
     @Unroll
-    def "schemas are generated into task-specific directory and are cacheable with kotlin and kapt workers disabled (Android #androidVersion)"() {
+    def "schemas are generated into task-specific directory and are cacheable with kotlin and kapt workers disabled (Android #androidVersion) (Kotlin #kotlinVersion)"() {
         SimpleAndroidApp.builder(temporaryFolder.root, cacheDir)
             .withAndroidVersion(androidVersion)
+            .withKotlinVersion(VersionNumber.parse(kotlinVersion))
             .withKaptWorkersDisabled()
             .build()
             .writeProject()
@@ -134,7 +137,8 @@ class RoomSchemaLocationWorkaroundTest extends AbstractTest {
         assertMergedSchemaOutputsExist()
 
         where:
-        androidVersion << TestVersions.latestAndroidVersions
+        //noinspection GroovyAssignabilityCheck
+        [androidVersion, kotlinVersion] << [TestVersions.latestAndroidVersions, TestVersions.supportedKotlinVersions].combinations()
     }
 
     @Unroll

--- a/src/test/groovy/org/gradle/android/SimpleAndroidApp.groovy
+++ b/src/test/groovy/org/gradle/android/SimpleAndroidApp.groovy
@@ -452,7 +452,7 @@ class SimpleAndroidApp {
         RoomConfiguration roomConfiguration = RoomConfiguration.ROOM_EXTENSION
 
         VersionNumber androidVersion = Versions.latestAndroidVersion()
-        VersionNumber kotlinVersion = VersionNumber.parse("1.3.72")
+        VersionNumber kotlinVersion = TestVersions.latestSupportedKotlinVersion()
         File projectDir
         File cacheDir
 

--- a/src/test/groovy/org/gradle/android/TestVersions.groovy
+++ b/src/test/groovy/org/gradle/android/TestVersions.groovy
@@ -41,4 +41,21 @@ class TestVersions {
         def minorVersions = allCandidateTestVersions.keySet().collect { "${it.major}.${it.minor}" }
         return minorVersions.collect { getLatestVersionForAndroid(it) }
     }
+
+    static List<String> supportedKotlinVersions = ["1.3.72", "1.5.0"]
+
+    static VersionNumber oldestSupportedKotlinVersion() {
+        return VersionNumber.parse(supportedKotlinVersions.first())
+    }
+
+    static VersionNumber latestSupportedKotlinVersion() {
+        return VersionNumber.parse(supportedKotlinVersions.last())
+    }
+
+    static VersionNumber latestKotlinVersionForGradleVersion(GradleVersion gradleVersion) {
+        if (gradleVersion < GradleVersion.version("6.1")) {
+            return oldestSupportedKotlinVersion()
+        }
+        return latestSupportedKotlinVersion()
+    }
 }


### PR DESCRIPTION
This adds tests for the newest and oldest supported kotlin versions in the `RoomSchemaLocationWorkaroundTest`.
The other relocation tests will default to the latest supported version.
