### PR TITLE
Fix issues with room schema merge

### DIFF
--- a/.github/workflows/ci-check.yml
+++ b/.github/workflows/ci-check.yml
@@ -76,7 +76,7 @@ jobs:
     -   name: Setup NDK
         run: sudo $ANDROID_HOME/tools/bin/sdkmanager 'ndk;20.0.5594570'
 
-    # Patch issue in platform-tools 31.0.3 where platform-tools/api/api-versions.xml is missing
+    # Patch issue in platform-tools 31.0.3 where platform-tools/api/api-versions.xml is missing (see https://issuetracker.google.com/issues/195445762)
     -   name: Patch api-versions
         run: sudo test -f $ANDROID_HOME/platform-tools/api/api-versions.xml || (sudo mkdir $ANDROID_HOME/platform-tools/api && sudo cp .github/api-versions.xml $ANDROID_HOME/platform-tools/api/api-versions.xml)
 

--- a/src/test/groovy/org/gradle/android/RoomSchemaLocationWorkaroundTest.groovy
+++ b/src/test/groovy/org/gradle/android/RoomSchemaLocationWorkaroundTest.groovy
@@ -243,7 +243,7 @@ class RoomSchemaLocationWorkaroundTest extends AbstractTest {
     def "schemas are correctly generated when only one variant is built incrementally (Android #androidVersion)"() {
         SimpleAndroidApp.builder(temporaryFolder.root, cacheDir)
             .withAndroidVersion(androidVersion)
-            .withKotlinVersion(VersionNumber.parse("1.5.0"))
+            .withKotlinVersion(TestVersions.latestSupportedKotlinVersion())
             .build()
             .writeProject()
 
@@ -452,6 +452,7 @@ class RoomSchemaLocationWorkaroundTest extends AbstractTest {
     void assertSchemasExist(String project, String baseDirPath) {
         assert file("${roomSchemaDirPath(project, baseDirPath)}/1.json").exists()
         assert file("${roomSchemaDirPath(project, baseDirPath)}/2.json").exists()
+        assertLegacySchemaUnchanged(file("${roomSchemaDirPath(project, baseDirPath)}/1.json"))
     }
 
     static String roomSchemaDirPath(String project, String baseDirPath) {
@@ -485,5 +486,9 @@ class RoomSchemaLocationWorkaroundTest extends AbstractTest {
         def schemaSourceFile = file("${project}/src/main/java/org/gradle/android/example/${project}/JavaUser.java")
         schemaSourceFile.text = schemaSourceFile.text.replaceAll("ColumnInfo\\(name = .${oldColumnName}.\\)", "ColumnInfo(name = \"${newColumnName}\")")
         assert schemaSourceFile.text.contains("@ColumnInfo(name = \"${newColumnName}\")")
+    }
+
+    static void assertLegacySchemaUnchanged(File legacySchemaFile) {
+        assert legacySchemaFile.text == SimpleAndroidApp.legacySchemaContents
     }
 }

--- a/src/test/groovy/org/gradle/android/SimpleAndroidApp.groovy
+++ b/src/test/groovy/org/gradle/android/SimpleAndroidApp.groovy
@@ -366,7 +366,12 @@ class SimpleAndroidApp {
                 }
             """.stripIndent()
 
-            file("${basedir}/schemas/${packageName}.AppDatabase/1.json") << '''
+            file("${basedir}/schemas/${packageName}.AppDatabase/1.json") << legacySchemaContents
+        }
+    }
+
+    static String getLegacySchemaContents() {
+        return '''
                 {
                   "formatVersion": 1,
                   "database": {
@@ -414,7 +419,6 @@ class SimpleAndroidApp {
                   }
                 }
             '''.stripIndent()
-        }
     }
 
     private static String activityDependency() {


### PR DESCRIPTION
This fixes an issue where an incremental build of a single variant with a Room schema change can result in the wrong schemas being merged to the target folder.  

It also changes the way we handle JavaCompile vs Kapt handling so that it's more resilient and less likely to result in incorrect schemas being merged.