### PR TITLE
Use AndroidBasePlugin instead of deprecated BasePlugin.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ plugins {
 }
 
 subprojects {
-    plugins.withType(com.android.build.gradle.BasePlugin) {
+    plugins.withType(com.android.build.gradle.api.AndroidBasePlugin) {
         project.apply plugin: "org.gradle.android.cache-fix"
     }
 }
@@ -52,7 +52,7 @@ plugins {
 }
 
 subprojects {
-    plugins.withType<com.android.build.gradle.BasePlugin>() {
+    plugins.withType<com.android.build.gradle.api.AndroidBasePlugin>() {
         apply(plugin = "org.gradle.android.cache-fix")
     }
 }


### PR DESCRIPTION
The AndroidBasePlugin is the correct way to determine if the Android plugin was applied. It is available since AGP 3.5

See this PR for our tests executed against this version of the README: https://github.com/gradle/android-cache-fix-gradle-plugin/pull/185