### PR TITLE
Use new ID for Gradle GitHub action

### DIFF
--- a/.github/workflows/ci-check.yml
+++ b/.github/workflows/ci-check.yml
@@ -34,8 +34,6 @@ jobs:
         matrix: ${{ steps.setup-matrix.outputs.matrix }}
 
   sanity_check:
-    needs: generate_versions
-
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Since `eskatos/gradle-command-action` now redirects to `gradle/gradle-build-action`, this is effectively a no-op.