### PR TITLE
Fix non-relocatable build caching for test task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -140,7 +140,8 @@ tasks.register('generateTestTasksJson') {
 // Configuration common to all test tasks
 tasks.withType(Test).configureEach {
     dependsOn publish
-    systemProperty "local.repo", localRepo.toURI()
+    workingDir projectDir
+    systemProperty "local.repo", projectDir.toPath().relativize(localRepo.toPath()).toString()
     useJUnitPlatform()
     retry {
         maxRetries = isCI ? 1 : 0

--- a/src/test/groovy/org/gradle/android/SimpleAndroidApp.groovy
+++ b/src/test/groovy/org/gradle/android/SimpleAndroidApp.groovy
@@ -2,6 +2,8 @@ package org.gradle.android
 
 import org.gradle.util.VersionNumber
 
+import java.nio.file.Paths
+
 import static org.gradle.android.Versions.android
 
 class SimpleAndroidApp {
@@ -43,13 +45,15 @@ class SimpleAndroidApp {
                 }
             """.stripIndent()
 
+        def localRepo = Paths.get(System.getProperty("local.repo")).toUri()
+
         file("build.gradle") << """
                 buildscript {
                     repositories {
                         google()
                         jcenter()
                         maven {
-                            url = "${System.getProperty("local.repo")}"
+                            url = "${localRepo}"
                         }
                     }
                     dependencies {


### PR DESCRIPTION
Does what the title says and makes the `test` task fully cachable.  It relativizes the local repository using the project dir, and explicitly uses the project dir as the working dir.