### PR TITLE
Fix issue with spurious CompileLibraryResourcesWorkaround warnings

### DIFF
--- a/src/main/groovy/org/gradle/android/AndroidCacheFixPlugin.groovy
+++ b/src/main/groovy/org/gradle/android/AndroidCacheFixPlugin.groovy
@@ -61,7 +61,7 @@ class AndroidCacheFixPlugin implements Plugin<Project> {
 
         if (!isSupportedAndroidVersion(project)) {
             if (isMaybeSupportedAndroidVersion(project)) {
-                Warnings.MAYBE_SUPPORTED_ANDROID_VERSION.warnOnce(project.logger)
+                Warnings.MAYBE_SUPPORTED_ANDROID_VERSION.warnOnce(project)
             } else {
                 throw new RuntimeException("Android plugin ${CURRENT_ANDROID_VERSION} is not supported by Android cache fix plugin. Supported Android plugin versions: ${SUPPORTED_ANDROID_VERSIONS.join(", ")}. Override with -D${IGNORE_VERSION_CHECK_PROPERTY}=true.")
             }

--- a/src/main/groovy/org/gradle/android/Warnings.groovy
+++ b/src/main/groovy/org/gradle/android/Warnings.groovy
@@ -2,6 +2,7 @@ package org.gradle.android
 
 import groovy.transform.CompileStatic
 import org.gradle.android.workarounds.CompileLibraryResourcesWorkaround
+import org.gradle.api.Project
 
 import java.util.concurrent.atomic.AtomicBoolean
 
@@ -17,9 +18,9 @@ enum Warnings {
         this.warning = warning
     }
 
-    void warnOnce(org.gradle.api.logging.Logger logger) {
-        if (!warned.getAndSet(true)) {
-            logger.warn(warning)
+    void warnOnce(Project project) {
+        if (isNotKotlinDslAccessors(project) && !warned.getAndSet(true)) {
+            project.logger.warn(warning)
         }
     }
 
@@ -29,5 +30,9 @@ enum Warnings {
 
     static void resetAll() {
         values().each {it.reset() }
+    }
+
+    static boolean isNotKotlinDslAccessors(Project project) {
+        return project.rootProject.name != "gradle-kotlin-dsl-accessors"
     }
 }

--- a/src/main/groovy/org/gradle/android/workarounds/CompileLibraryResourcesWorkaround.groovy
+++ b/src/main/groovy/org/gradle/android/workarounds/CompileLibraryResourcesWorkaround.groovy
@@ -21,7 +21,7 @@ class CompileLibraryResourcesWorkaround implements Workaround {
         boolean cacheCompileLibResources = Boolean.valueOf(context.project.findProperty(CACHE_COMPILE_LIB_RESOURCES) as String)
 
         if (!(enableSourceSetPathsMap && cacheCompileLibResources)) {
-            Warnings.USE_COMPILE_LIBRARY_RESOURCES_EXPERIMENTAL.warnOnce(context.project.logger)
+            Warnings.USE_COMPILE_LIBRARY_RESOURCES_EXPERIMENTAL.warnOnce(context.project)
         }
     }
 

--- a/src/test/groovy/org/gradle/android/SimpleAndroidApp.groovy
+++ b/src/test/groovy/org/gradle/android/SimpleAndroidApp.groovy
@@ -38,11 +38,6 @@ class SimpleAndroidApp {
         def libPackage = 'org.gradle.android.example.library'
         def libraryActivity = 'LibraryActivity'
 
-        def pluginVersion = System.getProperty(PLUGIN_VERSION_SYSTEM_PROPERTY)
-        if (pluginVersion == null) {
-            throw new IllegalStateException("The '${PLUGIN_VERSION_SYSTEM_PROPERTY}' system property must be set in order to apply the plugin under test!")
-        }
-
         file("settings.gradle") << """
                 buildCache {
                     local {
@@ -50,8 +45,6 @@ class SimpleAndroidApp {
                     }
                 }
             """.stripIndent()
-
-        def localRepo = Paths.get(System.getProperty("local.repo")).toUri()
 
         file("build.gradle") << """
                 buildscript {
@@ -87,7 +80,7 @@ class SimpleAndroidApp {
                     <application android:label="@string/app_name" >
                         <activity
                             android:name=".${appActivity}"
-                            android:label="@string/app_name" 
+                            android:label="@string/app_name"
                             android:exported="false">
                             <intent-filter>
                                 <action android:name="android.intent.action.MAIN" />
@@ -131,6 +124,18 @@ class SimpleAndroidApp {
             """.stripIndent()
 
         configureAndroidSdkHome()
+    }
+
+    static String getPluginVersion() {
+        def pluginVersion = System.getProperty(PLUGIN_VERSION_SYSTEM_PROPERTY)
+        if (pluginVersion == null) {
+            throw new IllegalStateException("The '${PLUGIN_VERSION_SYSTEM_PROPERTY}' system property must be set in order to apply the plugin under test!")
+        }
+        return pluginVersion
+    }
+
+    static String getLocalRepo() {
+        return Paths.get(System.getProperty("local.repo")).toUri()
     }
 
     private String getKotlinPluginDependencyIfEnabled() {


### PR DESCRIPTION
When a Kotlin script plugin is compiled, Gradle runs a nested build with the applied plugins in order to inspect/generate the type-safe accessors for the script.  When a Kotlin script plugin applies the cache-fix plugin, the plugin is applied to the nested build without inheriting the Gradle properties from the main build.  This causes the warnings from workarounds like `CompileLibraryResourcesWorkaround` to get printed to the console, even though the properties that it references are actually applied in the main project.

This fixes the issue by inhibiting warnings when we detect that we're in the nested build for generating type-safe accessors.  We detect this by just looking at the root project name, so there is of course the possibility of another project that just happens to be named `gradle-kotlin-dsl-accessors` potentially having their warnings inhibited, but I think this is extremely low probability.

Fixes #234 