### PR TITLE
Use separate "Set up Gradle" step in GHActions

### DIFF
--- a/.github/workflows/build-verification.yml
+++ b/.github/workflows/build-verification.yml
@@ -33,9 +33,10 @@ jobs:
         with:
           java-version: 11
           distribution: 'adopt'
-      - uses: gradle/gradle-build-action@v2
-        with:
-          arguments: sanityCheck
+      - name: Set up Gradle
+        uses: gradle/gradle-build-action@v2
+      - name: Run sanityCheck
+        run: ./gradlew sanityCheck
 
   android_version_tests:
     name: Android version tests
@@ -52,10 +53,12 @@ jobs:
         run: sudo test -f $ANDROID_HOME/platform-tools/api/api-versions.xml || (sudo mkdir $ANDROID_HOME/platform-tools/api && sudo cp .github/api-versions.xml $ANDROID_HOME/platform-tools/api/api-versions.xml)
       - name: List Android Packages
         run: sudo $ANDROID_HOME/tools/bin/sdkmanager --list | sed -n '/Available Packages/q;p'
-      - uses: actions/setup-java@v2
+      - name: Set up Java
+        uses: actions/setup-java@v2
         with:
           java-version: 11
           distribution: 'adopt'
-      - uses: gradle/gradle-build-action@v2
-        with:
-          arguments: testAndroid${{ matrix.versions }} -x signArchives
+      - name: Set up Gradle
+        uses: gradle/gradle-build-action@v2
+      - name: Build and test
+        run: ./gradlew testAndroid${{ matrix.versions }} -x signArchives

--- a/.github/workflows/wrapper-upgrade-execution.yml
+++ b/.github/workflows/wrapper-upgrade-execution.yml
@@ -31,9 +31,9 @@ jobs:
         with:
           java-version: '11'
           distribution: 'adopt'
-      - name: Upgrade Wrappers
+      - name: Set up Gradle
         uses: gradle/gradle-build-action@v2
-        with:
-          arguments: 'clean upgradeGradleWrapperAll --continue'
+      - name: Upgrade Wrappers
+        run: ./gradlew clean upgradeGradleWrapperAll --continue
         env:
           WRAPPER_UPGRADE_GIT_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Separating the setup of the Gradle build tool from actual build invocation
is more idiomatic to GH Actions in general, and provides a clearer separation
of responsibilities.