### PR TITLE
Remove CompileLibraryResourcesWorkaround in AGP 7.2.0-beta01+

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 Some Android plugin versions have issues with Gradle's build cache feature. When applied to an Android project this plugin applies workarounds for these issues based on the Android plugin and Gradle versions. For other versions, please see [older versions.](#older-android-gradle-plugin-versions)
 
 * Supported Gradle versions: 7.0+
-* Supported Android Gradle Plugin versions: 7.0.4, 7.1.3, 7.2.0-beta04, 7.3.0-alpha07
+* Supported Android Gradle Plugin versions: 7.0.4, 7.1.3, 7.2.0-beta04, 7.3.0-alpha08
 * Supported Kotlin versions: 1.4.32+
 
 We only test against the latest patch versions of each minor version of Android Gradle Plugin.  This means that although it may work perfectly well with an older patch version (say 7.0.1), we do not test against these older patch versions, so the latest patch version is the only version from that minor release that we technically support.

--- a/release/changes.md
+++ b/release/changes.md
@@ -1,0 +1,3 @@
+* Remove cache disabling fixes for tasks marked as non-cacheable.
+* Support latest versions of AGP
+* Fix for false positive warning in kotlin-dsl-accessors build.

--- a/release/changes.md
+++ b/release/changes.md
@@ -1,3 +1,4 @@
 * Remove workarounds for tasks already marked as non-cacheable.
 * Support latest versions of AGP.
 * Fix for false positive warnings in kotlin-dsl-accessors build.
+* Publish signature for jar file.

--- a/release/changes.md
+++ b/release/changes.md
@@ -1,3 +1,3 @@
-* Remove cache disabling fixes for tasks marked as non-cacheable.
-* Support latest versions of AGP
-* Fix for false positive warning in kotlin-dsl-accessors build.
+* Remove workarounds for tasks already marked as non-cacheable.
+* Support latest versions of AGP.
+* Fix for false positive warnings in kotlin-dsl-accessors build.

--- a/src/main/groovy/org/gradle/android/workarounds/CompileLibraryResourcesWorkaround.groovy
+++ b/src/main/groovy/org/gradle/android/workarounds/CompileLibraryResourcesWorkaround.groovy
@@ -9,7 +9,7 @@ import org.gradle.api.Project
  * Warns if the user is not using experimental support for relative path sensitivity that was added
  * with 7.0.0-alpha09.
  */
-@AndroidIssue(introducedIn = "7.0.0-alpha09", fixedIn = [], link = "https://issuetracker.google.com/issues/155218379")
+@AndroidIssue(introducedIn = "7.0.0-alpha09", fixedIn = "7.2.0-beta01", link = "https://issuetracker.google.com/issues/155218379")
 @CompileStatic
 class CompileLibraryResourcesWorkaround implements Workaround {
     public static final String ENABLE_SOURCE_SET_PATHS_MAP = "android.experimental.enableSourceSetPathsMap"

--- a/src/test/groovy/org/gradle/android/CompileLibraryResourcesWorkaroundTest.groovy
+++ b/src/test/groovy/org/gradle/android/CompileLibraryResourcesWorkaroundTest.groovy
@@ -8,6 +8,7 @@ import spock.lang.Issue
 class CompileLibraryResourcesWorkaroundTest extends AbstractTest {
     def "warns when experimental flags are not provided"() {
         Assume.assumeTrue(TestVersions.latestAndroidVersionForCurrentJDK() >= Versions.android("7.0.0-alpha09"))
+        Assume.assumeTrue(TestVersions.latestAndroidVersionForCurrentJDK() < Versions.android("7.2.0-beta01"))
 
         SimpleAndroidApp.builder(temporaryFolder.root, cacheDir)
             .withAndroidVersion(TestVersions.latestAndroidVersionForCurrentJDK())
@@ -44,6 +45,7 @@ class CompileLibraryResourcesWorkaroundTest extends AbstractTest {
 
     def "does not warn when experimental flags are provided"() {
         Assume.assumeTrue(TestVersions.latestAndroidVersionForCurrentJDK() >= Versions.android("7.0.0-alpha09"))
+        Assume.assumeTrue(TestVersions.latestAndroidVersionForCurrentJDK() <= Versions.android("7.2.0-beta01"))
 
         SimpleAndroidApp.builder(temporaryFolder.root, cacheDir)
             .withAndroidVersion(TestVersions.latestAndroidVersionForCurrentJDK())

--- a/src/test/groovy/org/gradle/android/WorkaroundTest.groovy
+++ b/src/test/groovy/org/gradle/android/WorkaroundTest.groovy
@@ -12,8 +12,8 @@ class WorkaroundTest extends Specification {
         workarounds.collect { it.class.simpleName.replaceAll(/Workaround/, "") }.sort() == expectedWorkarounds.sort()
         where:
         androidVersion  | expectedWorkarounds
-        "7.3.0-alpha08" | ['CompileLibraryResources', 'MergeNativeLibs', 'MergeSourceSetFolders', 'RoomSchemaLocation', 'ZipMergingTask']
-        "7.2.0-beta04"  | ['CompileLibraryResources', 'MergeNativeLibs', 'MergeSourceSetFolders', 'RoomSchemaLocation', 'ZipMergingTask']
+        "7.3.0-alpha08" | ['MergeNativeLibs', 'MergeSourceSetFolders', 'RoomSchemaLocation', 'ZipMergingTask']
+        "7.2.0-beta04"  | ['MergeNativeLibs', 'MergeSourceSetFolders', 'RoomSchemaLocation', 'ZipMergingTask']
         "7.1.3"         | ['BundleLibraryClasses', 'CompileLibraryResources', 'DataBindingMergeDependencyArtifacts', 'LibraryJniLibs', 'MergeNativeLibs', 'MergeSourceSetFolders', 'RoomSchemaLocation', 'StripDebugSymbols', 'ZipMergingTask']
         "7.0.4"         | ['BundleLibraryClasses', 'CompileLibraryResources', 'DataBindingMergeDependencyArtifacts', 'LibraryJniLibs', 'MergeNativeLibs', 'MergeSourceSetFolders', 'RoomSchemaLocation', 'StripDebugSymbols', 'ZipMergingTask']
     }


### PR DESCRIPTION
Fixes #281
