### PR TITLE
Fix issue with static method not being found sometimes with @CompileStatic

### DIFF
--- a/src/main/groovy/org/gradle/android/workarounds/RoomSchemaLocationWorkaround.groovy
+++ b/src/main/groovy/org/gradle/android/workarounds/RoomSchemaLocationWorkaround.groovy
@@ -119,7 +119,7 @@ class RoomSchemaLocationWorkaround implements Workaround {
                 // Seed the task-specific generated schema dir with the existing schemas
                 task.doFirst {
                     if (javaCompileSchemaGenerationEnabled) {
-                        copyExistingSchemasToTaskSpecificTmpDir(fileOperations, roomExtension.schemaLocationDir, taskSpecificSchemaDir)
+                        RoomSchemaLocationWorkaround.copyExistingSchemasToTaskSpecificTmpDir(fileOperations, roomExtension.schemaLocationDir, taskSpecificSchemaDir)
                     }
                 }
 


### PR DESCRIPTION
For some reason, Groovy sometimes doesn't find static methods while crawling the delegation tree when a class is compiled with @CompileStatic.  Making the method call fully qualified seems to fix it.  We fixed this in several places when we added `@CompileStatic` to these classes, but we missed this one.

Fixes #285