### PR TITLE
Remove configuration cache compatibility line for publishPlugin task.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -179,10 +179,6 @@ tasks.named("githubRelease").configure {
     dependsOn("createReleaseTag")
 }
 
-tasks.named('publishPlugins').configure {
-    notCompatibleWithConfigurationCache("$name task does not support configuration caching")
-}
-
 tasks.withType(Sign).configureEach {
     notCompatibleWithConfigurationCache("$name task does not support configuration caching")
 }


### PR DESCRIPTION
This is now done by the publish plugin itself.
