### PR TITLE
Fix a failure when ZULU_ env vars are not set

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -121,8 +121,8 @@ supportedVersions.keySet().each { androidVersion ->
         group = "verification"
 
         systemProperty 'org.gradle.android.testVersion', androidVersion
-        systemProperty 'org.gradle.android.java_zulu_path', project.providers.environmentVariable('ZULU_JDK').get()
-        systemProperty 'org.gradle.android.java_zulu_alt_path', project.providers.environmentVariable('ZULU_ALT_JDK').get()
+        systemProperty 'org.gradle.android.java_zulu_path', project.providers.environmentVariable('ZULU_JDK').getOrNull()
+        systemProperty 'org.gradle.android.java_zulu_alt_path', project.providers.environmentVariable('ZULU_ALT_JDK').getOrNull()
     }
 
     tasks.named('check').configure {


### PR DESCRIPTION
The new plugin-publish plugin somehow configures the test task on publishing.