### PR TITLE
Fix issue with ordering on serialized module descriptors

### DIFF
--- a/src/main/groovy/org/gradle/android/workarounds/JdkImageWorkaround.groovy
+++ b/src/main/groovy/org/gradle/android/workarounds/JdkImageWorkaround.groovy
@@ -44,13 +44,18 @@ class JdkImageWorkaround implements Workaround {
 
     @Override
     void apply(Project project) {
+        // We would prefer not to configure this if a jdkImage is not in use, but the attributes
+        // being ignored are unlikely to ever have a runtime impact.  Doing this outside of task
+        // configuration prevents issues with things that use the tooling api to finalize the
+        // runtime configuration before querying (and instantiating) task configurations.
+        applyRuntimeClasspathNormalization(project)
+
         applyToAllAndroidVariants(project) { variant ->
             variant.javaCompileProvider.configure { JavaCompile task ->
                 def jdkImageInput = getJdkImageInput(task)
                 if (jdkImageInput != null) {
                     setupExtractedJdkImageInputTransform(project, getJvmHome(task))
                     replaceCommandLineProvider(task, jdkImageInput)
-                    applyRuntimeClasspathNormalization(task.project)
                 }
             }
         }

--- a/src/test/groovy/org/gradle/android/JdkImageWorkaroundDescriptorTest.groovy
+++ b/src/test/groovy/org/gradle/android/JdkImageWorkaroundDescriptorTest.groovy
@@ -1,0 +1,63 @@
+package org.gradle.android
+
+import com.google.common.collect.Sets
+import org.gradle.android.workarounds.JdkImageWorkaround
+import spock.lang.Specification
+import spock.lang.Unroll
+
+import java.lang.module.ModuleDescriptor
+
+class JdkImageWorkaroundDescriptorTest extends Specification {
+    def "normalizes module descriptors with different orders in the values"() {
+        given:
+        def serialized1 = JdkImageWorkaround.ExtractJdkImageTransform.serializeDescriptor(descriptor(["org.foo", "org.bar"], ["baz", "fizz"]))
+        def serialized2 = JdkImageWorkaround.ExtractJdkImageTransform.serializeDescriptor(descriptor(["org.bar", "org.foo"], ["fizz", "baz"]))
+
+        expect:
+        serialized1 == serialized2
+    }
+
+    def "descriptors with different values are serialized differently"() {
+        given:
+        def serialized1 = JdkImageWorkaround.ExtractJdkImageTransform.serializeDescriptor(descriptor(["org.foo", "org.bar"], ["baz", "fizz"]))
+        def serialized2 = JdkImageWorkaround.ExtractJdkImageTransform.serializeDescriptor(descriptor(["org.bar", "org.foo", "org.baz"], ["baz", "fizz"]))
+
+        expect:
+        serialized1 != serialized2
+    }
+
+    @Unroll
+    def "all descriptor values are captured (#modifier.trim())"() {
+        ModuleDescriptor descriptor = builder
+            .requires("foo").requires("bar")
+            .uses("org.baz").uses("org.fizz")
+            .exports("org.exports", ["exportsTarget1", "exportsTarget2"] as Set)
+            .provides("org.provides", ["org.provider1", "org.provider2"])
+            .with {
+                modifier == "" ? opens("org.opens", ["opensTarget1", "opensTarget2"] as Set) : it
+            }.build()
+
+        expect:
+        JdkImageWorkaround.ExtractJdkImageTransform.serializeDescriptor(descriptor) == "${modifier}module { name: myModule, " +
+            "[bar, foo, mandated java.base], " +
+            "uses: [org.baz, org.fizz], " +
+            "exports: [org.exports to [exportsTarget1, exportsTarget2]], " +
+            (modifier == "" ? "opens: [org.opens to [opensTarget1, opensTarget2]], " : "") +
+            "provides: [org.provides with [org.provider1, org.provider2]] }"
+
+        where:
+        builder                                    | modifier
+        ModuleDescriptor.newModule("myModule")     | ""
+        ModuleDescriptor.newOpenModule("myModule") | "open "
+    }
+
+    static def descriptor(List<String> packages, List<String> values) {
+        ModuleDescriptor.Builder builder = ModuleDescriptor.newModule("myModule")
+        values.each { builder.requires(it) }
+        packages.each { builder.uses(it) }
+        packages.each { builder.exports("${it}.exports", Sets.newLinkedHashSet(values)) }
+        packages.each { builder.opens("${it}.opens", Sets.newLinkedHashSet(values)) }
+        packages.each { builder.provides("${it}.provides", values.collect { v -> "org.${v}".toString() }) }
+        return builder.build()
+    }
+}


### PR DESCRIPTION
This fixes an issue in the JdkImageWorkaround where module-descriptors.txt could have different ordering for its contents due to different hashing algorithms across operating systems.  Instead of using the `toString()` method, we now serialize the module descriptor ourself and sort any unordered sets in the descriptor so that equivalent module descriptors will always serialize to the same contents.

This also fixes an issue where the runtime classpath normalization could sometimes be configured after it had been finalized.