### PR TITLE
Allow room workaround to be disabled

### DIFF
--- a/.github/workflows/build-verification.yml
+++ b/.github/workflows/build-verification.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Set up Gradle
         uses: gradle/gradle-build-action@v2
       - name: Run unit tests
-        run: ./gradlew test -x signPluginMavenPublication -x signAndroidCacheFixPluginPluginMarkerMavenPublication
+        run: ./gradlew test -x signPluginMavenPublication -x signAndroidCacheFixPluginPluginMarkerMavenPublication --info
 
   android_version_tests:
     name: Android version tests

--- a/src/main/groovy/org/gradle/android/workarounds/RoomSchemaLocationWorkaround.groovy
+++ b/src/main/groovy/org/gradle/android/workarounds/RoomSchemaLocationWorkaround.groovy
@@ -59,7 +59,6 @@ class RoomSchemaLocationWorkaround implements Workaround {
     @Override
     boolean canBeApplied(Project project) {
         if (KOTLIN_VERSION != VersionNumber.UNKNOWN && KOTLIN_VERSION < MINIMUM_KOTLIN_VERSION) {
-            SystemPropertiesCompat.getBoolean(WORKAROUND_ENABLED_PROPERTY, project, true)
             project.logger.info("${this.class.simpleName} is only compatible with Kotlin Gradle plugin version 1.4.32 or higher (found ${KOTLIN_VERSION.toString()}).")
             return false
         } else {

--- a/src/main/groovy/org/gradle/android/workarounds/RoomSchemaLocationWorkaround.groovy
+++ b/src/main/groovy/org/gradle/android/workarounds/RoomSchemaLocationWorkaround.groovy
@@ -51,6 +51,7 @@ import java.util.function.Supplier
  */
 @AndroidIssue(introducedIn = "3.5.0", fixedIn = [], link = "https://issuetracker.google.com/issues/132245929")
 class RoomSchemaLocationWorkaround implements Workaround {
+    public static final String WORKAROUND_ENABLED_PROPERTY = "org.gradle.android.cache-fix.RoomSchemaLocationWorkaround.enabled"
     public static final String ROOM_SCHEMA_LOCATION = "room.schemaLocation"
     private static final VersionNumber MINIMUM_KOTLIN_VERSION = VersionNumber.parse("1.4.32")
     private static final VersionNumber KOTLIN_VERSION = getKotlinVersion()
@@ -58,10 +59,11 @@ class RoomSchemaLocationWorkaround implements Workaround {
     @Override
     boolean canBeApplied(Project project) {
         if (KOTLIN_VERSION != VersionNumber.UNKNOWN && KOTLIN_VERSION < MINIMUM_KOTLIN_VERSION) {
+            SystemPropertiesCompat.getBoolean(WORKAROUND_ENABLED_PROPERTY, project, true)
             project.logger.info("${this.class.simpleName} is only compatible with Kotlin Gradle plugin version 1.4.32 or higher (found ${KOTLIN_VERSION.toString()}).")
             return false
         } else {
-            return true
+            return SystemPropertiesCompat.getBoolean(WORKAROUND_ENABLED_PROPERTY, project, true)
         }
     }
 

--- a/src/test/groovy/org/gradle/android/RoomSchemaLocationWorkaroundTest.groovy
+++ b/src/test/groovy/org/gradle/android/RoomSchemaLocationWorkaroundTest.groovy
@@ -421,15 +421,13 @@ class RoomSchemaLocationWorkaroundTest extends AbstractTest {
 
         where:
         //noinspection GroovyAssignabilityCheck
-        [androidVersion, kotlinVersion] << [TestVersions.latestAndroidVersions, TestVersions.supportedKotlinVersions].combinations()
+        androidVersion << TestVersions.latestAndroidVersionswhere
     }
 
     @Unroll
     def "workaround is enabled when enabled via system property (Android #androidVersion)"() {
-        def androidVersion = TestVersions.latestAndroidVersionForCurrentJDK()
         SimpleAndroidApp.builder(temporaryFolder.root, cacheDir)
             .withAndroidVersion(androidVersion)
-            .withKotlinVersion(TestVersions.latestSupportedKotlinVersion())
             .build()
             .writeProject()
 
@@ -450,6 +448,10 @@ class RoomSchemaLocationWorkaroundTest extends AbstractTest {
 
         and:
         buildResult.task(':app:mergeRoomSchemaLocations').outcome == SUCCESS
+
+        where:
+        //noinspection GroovyAssignabilityCheck
+        androidVersion << TestVersions.latestAndroidVersions
     }
 
     void assertNotExecuted(buildResult, String taskPath) {

--- a/src/test/groovy/org/gradle/android/RoomSchemaLocationWorkaroundTest.groovy
+++ b/src/test/groovy/org/gradle/android/RoomSchemaLocationWorkaroundTest.groovy
@@ -412,7 +412,6 @@ class RoomSchemaLocationWorkaroundTest extends AbstractTest {
                 "--build-cache", "-D${RoomSchemaLocationWorkaround.WORKAROUND_ENABLED_PROPERTY}=false"
             ).build()
 
-
         then:
         noExceptionThrown()
 

--- a/src/test/groovy/org/gradle/android/RoomSchemaLocationWorkaroundTest.groovy
+++ b/src/test/groovy/org/gradle/android/RoomSchemaLocationWorkaroundTest.groovy
@@ -420,7 +420,7 @@ class RoomSchemaLocationWorkaroundTest extends AbstractTest {
 
         where:
         //noinspection GroovyAssignabilityCheck
-        androidVersion << TestVersions.latestAndroidVersionswhere
+        androidVersion << TestVersions.latestAndroidVersions
     }
 
     @Unroll

--- a/src/test/groovy/org/gradle/android/RoomSchemaLocationWorkaroundTest.groovy
+++ b/src/test/groovy/org/gradle/android/RoomSchemaLocationWorkaroundTest.groovy
@@ -392,6 +392,66 @@ class RoomSchemaLocationWorkaroundTest extends AbstractTest {
         !buildResult.output.contains('warning: The following options were not recognized by any processor: \'[room.schemaLocation')
     }
 
+    @Unroll
+    def "workaround can be disabled via system property (Android #androidVersion)"() {
+        SimpleAndroidApp.builder(temporaryFolder.root, cacheDir)
+            .withAndroidVersion(androidVersion)
+            .withRoomProcessingArgumentConfigured()
+            .build()
+            .writeProject()
+
+        cacheDir.deleteDir()
+        cacheDir.mkdirs()
+
+        when:
+        BuildResult buildResult = withGradleVersion(TestVersions.latestSupportedGradleVersionFor(androidVersion).version)
+            .forwardOutput()
+            .withProjectDir(temporaryFolder.root)
+            .withArguments(
+                "clean", "assemble",
+                "--build-cache", "-D${RoomSchemaLocationWorkaround.WORKAROUND_ENABLED_PROPERTY}=false"
+            ).build()
+
+
+        then:
+        noExceptionThrown()
+
+        and:
+        assertNotExecuted(buildResult, ':app:mergeRoomSchemaLocations')
+
+        where:
+        //noinspection GroovyAssignabilityCheck
+        [androidVersion, kotlinVersion] << [TestVersions.latestAndroidVersions, TestVersions.supportedKotlinVersions].combinations()
+    }
+
+    @Unroll
+    def "workaround is enabled when enabled via system property (Android #androidVersion)"() {
+        def androidVersion = TestVersions.latestAndroidVersionForCurrentJDK()
+        SimpleAndroidApp.builder(temporaryFolder.root, cacheDir)
+            .withAndroidVersion(androidVersion)
+            .withKotlinVersion(TestVersions.latestSupportedKotlinVersion())
+            .build()
+            .writeProject()
+
+        cacheDir.deleteDir()
+        cacheDir.mkdirs()
+
+        when:
+        BuildResult buildResult = withGradleVersion(TestVersions.latestSupportedGradleVersionFor(androidVersion).version)
+            .forwardOutput()
+            .withProjectDir(temporaryFolder.root)
+            .withArguments(
+                "clean", "assemble",
+                "--build-cache", "-D${RoomSchemaLocationWorkaround.WORKAROUND_ENABLED_PROPERTY}=true"
+            ).build()
+
+        then:
+        noExceptionThrown()
+
+        and:
+        buildResult.task(':app:mergeRoomSchemaLocations').outcome == SUCCESS
+    }
+
     void assertNotExecuted(buildResult, String taskPath) {
         assert !buildResult.tasks.collect {it.path }.contains(taskPath)
     }


### PR DESCRIPTION
Implements the ability to suppress RoomSchemaLocationWorkaround workarounds

Closes https://github.com/gradle/android-cache-fix-gradle-plugin/issues/289