### PR TITLE
Replace jcenter with mavenCentral

### DIFF
--- a/src/test/groovy/org/gradle/android/SimpleAndroidApp.groovy
+++ b/src/test/groovy/org/gradle/android/SimpleAndroidApp.groovy
@@ -55,7 +55,7 @@ class SimpleAndroidApp {
                 buildscript {
                     repositories {
                         google()
-                        jcenter()
+                        mavenCentral()
                         maven {
                             url = "${localRepo}"
                         }
@@ -161,7 +161,7 @@ class SimpleAndroidApp {
 
             repositories {
                 google()
-                jcenter()
+                mavenCentral()
             }
 
             dependencies {


### PR DESCRIPTION
We discovered that the tests are still building projects using jcenter, so this is a simple update to swap that out.  Hopefully all works correctly.