### PR TITLE
Don't use JdkImageWorkaround after 7.4.0-alpha07

### DIFF
--- a/src/main/groovy/org/gradle/android/workarounds/JdkImageWorkaround.groovy
+++ b/src/main/groovy/org/gradle/android/workarounds/JdkImageWorkaround.groovy
@@ -34,7 +34,7 @@ import java.util.stream.Stream
  * than Java 9.  This normalizes out minor inconsequential differences between JDKs used to generate the
  * custom runtime and improve cache hits between environments.
  */
-@AndroidIssue(introducedIn = "7.1.0", fixedIn = [], link = "https://issuetracker.google.com/u/1/issues/234820480")
+@AndroidIssue(introducedIn = "7.1.0", fixedIn = ['7.4.0-alpha07'], link = "https://issuetracker.google.com/u/1/issues/234820480")
 class JdkImageWorkaround implements Workaround {
     static final String WORKAROUND_ENABLED_PROPERTY = "org.gradle.android.cache-fix.JdkImageWorkaround.enabled"
 

--- a/src/test/groovy/org/gradle/android/JdkImageWorkaroundTest.groovy
+++ b/src/test/groovy/org/gradle/android/JdkImageWorkaroundTest.groovy
@@ -166,7 +166,7 @@ class JdkImageWorkaroundTest extends AbstractTest {
 
     def "workaround is enabled when enabled via system property"() {
         def androidVersion = TestVersions.latestAndroidVersionForCurrentJDK()
-        Assume.assumeTrue(androidVersion >= VersionNumber.parse("7.1.0-alpha01"))
+        Assume.assumeTrue(androidVersion >= VersionNumber.parse("7.1.0-alpha01")  && androidVersion < VersionNumber.parse("7.4.0-alpha07"))
         def gradleVersion = TestVersions.latestSupportedGradleVersionFor(androidVersion)
         SimpleAndroidApp.builder(temporaryFolder.root, cacheDir)
             .withAndroidVersion(androidVersion)

--- a/src/test/groovy/org/gradle/android/WorkaroundTest.groovy
+++ b/src/test/groovy/org/gradle/android/WorkaroundTest.groovy
@@ -12,7 +12,7 @@ class WorkaroundTest extends Specification {
         workarounds.collect { it.class.simpleName.replaceAll(/Workaround/, "") }.sort() == expectedWorkarounds.sort()
         where:
         androidVersion  | expectedWorkarounds
-        "7.4.0-alpha10" | ['MergeSourceSetFolders', 'RoomSchemaLocation', 'ZipMergingTask', 'JdkImage']
+        "7.4.0-alpha10" | ['MergeSourceSetFolders', 'RoomSchemaLocation', 'ZipMergingTask']
         "7.3.0-rc01"    | ['MergeSourceSetFolders', 'RoomSchemaLocation', 'ZipMergingTask', 'JdkImage']
         "7.2.2"         | ['MergeSourceSetFolders', 'RoomSchemaLocation', 'ZipMergingTask', 'JdkImage']
         "7.1.3"         | ['BundleLibraryClasses', 'CompileLibraryResources', 'DataBindingMergeDependencyArtifacts', 'LibraryJniLibs', 'MergeNativeLibs', 'MergeSourceSetFolders', 'RoomSchemaLocation', 'StripDebugSymbols', 'ZipMergingTask', 'JdkImage']


### PR DESCRIPTION
The issues that this workaround explicitly addresses should be fixed in 7.4.0-alpha07 per https://issuetracker.google.com/u/1/issues/234820480.  If using different JDK versions, it's still possible that further normalization might be necessary if aligning the versions is not possible.