### PR TITLE
MergeResources relocateability is fixed in 8.0.0-alpha01

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Please star them if you are experiencing them in your project.
 
 * Room annotation processor causes cache misses, doesn't declare outputs, overlapping outputs, etc: https://issuetracker.google.com/issues/132245929
 
-The following issue is not fixed by the Android Cache Fix plugin since it has no workaround and is not fixed in any current or future release of the Android Gradle Plugin.
+The following issue is not fixed by the Android Cache Fix plugin since it has no workaround but will be fixed in a future release of the Android Gradle Plugin (8.0.0-alpha01 or newer).
 * MergeResources is not relocatable: https://issuetracker.google.com/issues/236001083
 
 ## Implementation Notes


### PR DESCRIPTION
Fixes https://github.com/gradle/android-cache-fix-gradle-plugin/issues/367