### PR TITLE
Fix createReleaseTag ordering

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -171,12 +171,14 @@ githubRelease {
    targetCommitish = "main"
 }
 
-tasks.register('createReleaseTag', CreateGitTag) {
+def createReleaseTag = tasks.register('createReleaseTag', CreateGitTag) {
+    // Ensure tag is created only after successful publishing
+    mustRunAfter('publishPlugins')
     tagName = gitReleaseTag()
 }
 
 tasks.named("githubRelease").configure {
-    dependsOn("createReleaseTag")
+    dependsOn(createReleaseTag)
 }
 
 tasks.withType(Sign).configureEach {


### PR DESCRIPTION
This should ensure `createReleaseTag` is executed after `publishPlugins` whenever `publishPlugins githubRelease` is requested.