### PR TITLE
Set minimum Kotlin version to 1.6.10 and drop support Kotlin 1.5.32 

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Some Android plugin versions have issues with Gradle's build cache feature. When
 
 * Supported Gradle versions: 7.0+
 * Supported Android Gradle Plugin versions: 7.0.4, 7.1.3, 7.2.2, 7.3.1, 7.4.0-rc03, 8.0.0-alpha09
-* Supported Kotlin versions: 1.4.32+
+* Supported Kotlin versions: 1.6.10+
 
 We only test against the latest patch versions of each minor version of Android Gradle Plugin.  This means that although it may work perfectly well with an older patch version (say 7.0.1), we do not test against these older patch versions, so the latest patch version is the only version from that minor release that we technically support.
 
@@ -190,6 +190,9 @@ Use Android Cache Fix Plugin 2.4.6 when using an older Android Gradle Plugin ver
 
 * Supported Gradle versions: 5.4.1+
 * Supported Android Gradle Plugin versions: 3.5.4, 3.6.4, 4.0.1, 4.1.3, 4.2.2
+
+### Older Kotlin Gradle Plugin Versions
+Use Android Cache Fix Plugin 2.6.0 when using an older Kotlin Gradle Plugin version.
 * Supported Kotlin versions: 1.3.70+
 
 ## License

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Some Android plugin versions have issues with Gradle's build cache feature. When
 
 * Supported Gradle versions: 7.0+
 * Supported Android Gradle Plugin versions: 7.0.4, 7.1.3, 7.2.2, 7.3.1, 7.4.0-rc03, 8.0.0-alpha09
-* Supported Kotlin versions: 1.6.10+
+* Supported Kotlin versions: 1.6.0+
 
 We only test against the latest patch versions of each minor version of Android Gradle Plugin.  This means that although it may work perfectly well with an older patch version (say 7.0.1), we do not test against these older patch versions, so the latest patch version is the only version from that minor release that we technically support.
 

--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ Use Android Cache Fix Plugin 2.4.6 when using an older Android Gradle Plugin ver
 
 ### Older Kotlin Gradle Plugin Versions
 Use Android Cache Fix Plugin 2.6.0 when using an older Kotlin Gradle Plugin version.
-* Supported Kotlin versions: 1.3.70+
+* Supported Kotlin versions: 1.3.72, 1.4.32, 1.5.32
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ Use Android Cache Fix Plugin 2.4.6 when using an older Android Gradle Plugin ver
 
 ### Older Kotlin Gradle Plugin Versions
 Use Android Cache Fix Plugin 2.6.0 when using an older Kotlin Gradle Plugin version.
-* Supported Kotlin versions: 1.3.72, 1.4.32, 1.5.32
+* Supported Kotlin versions: \[1.3.72-1.5.32\]
 
 ## License
 

--- a/src/main/groovy/org/gradle/android/workarounds/RoomSchemaLocationWorkaround.groovy
+++ b/src/main/groovy/org/gradle/android/workarounds/RoomSchemaLocationWorkaround.groovy
@@ -54,13 +54,13 @@ import java.lang.reflect.Field
 class RoomSchemaLocationWorkaround implements Workaround {
     public static final String WORKAROUND_ENABLED_PROPERTY = "org.gradle.android.cache-fix.RoomSchemaLocationWorkaround.enabled"
     public static final String ROOM_SCHEMA_LOCATION = "room.schemaLocation"
-    private static final VersionNumber MINIMUM_KOTLIN_VERSION = VersionNumber.parse("1.6.10")
+    private static final VersionNumber MINIMUM_KOTLIN_VERSION = VersionNumber.parse("1.6.0")
     private static final VersionNumber KOTLIN_VERSION = getKotlinVersion()
 
     @Override
     boolean canBeApplied(Project project) {
         if (KOTLIN_VERSION != VersionNumber.UNKNOWN && KOTLIN_VERSION < MINIMUM_KOTLIN_VERSION) {
-            project.logger.info("${this.class.simpleName} is only compatible with Kotlin Gradle plugin version 1.6.10 or higher (found ${KOTLIN_VERSION.toString()}).")
+            project.logger.info("${this.class.simpleName} is only compatible with Kotlin Gradle plugin version 1.6.0 or higher (found ${KOTLIN_VERSION.toString()}).")
             return false
         } else {
             return SystemPropertiesCompat.getBoolean(WORKAROUND_ENABLED_PROPERTY, project, true)

--- a/src/main/groovy/org/gradle/android/workarounds/RoomSchemaLocationWorkaround.groovy
+++ b/src/main/groovy/org/gradle/android/workarounds/RoomSchemaLocationWorkaround.groovy
@@ -54,13 +54,13 @@ import java.lang.reflect.Field
 class RoomSchemaLocationWorkaround implements Workaround {
     public static final String WORKAROUND_ENABLED_PROPERTY = "org.gradle.android.cache-fix.RoomSchemaLocationWorkaround.enabled"
     public static final String ROOM_SCHEMA_LOCATION = "room.schemaLocation"
-    private static final VersionNumber MINIMUM_KOTLIN_VERSION = VersionNumber.parse("1.4.32")
+    private static final VersionNumber MINIMUM_KOTLIN_VERSION = VersionNumber.parse("1.6.10")
     private static final VersionNumber KOTLIN_VERSION = getKotlinVersion()
 
     @Override
     boolean canBeApplied(Project project) {
         if (KOTLIN_VERSION != VersionNumber.UNKNOWN && KOTLIN_VERSION < MINIMUM_KOTLIN_VERSION) {
-            project.logger.info("${this.class.simpleName} is only compatible with Kotlin Gradle plugin version 1.4.32 or higher (found ${KOTLIN_VERSION.toString()}).")
+            project.logger.info("${this.class.simpleName} is only compatible with Kotlin Gradle plugin version 1.6.10 or higher (found ${KOTLIN_VERSION.toString()}).")
             return false
         } else {
             return SystemPropertiesCompat.getBoolean(WORKAROUND_ENABLED_PROPERTY, project, true)

--- a/src/test/groovy/org/gradle/android/RoomSchemaLocationWorkaroundTest.groovy
+++ b/src/test/groovy/org/gradle/android/RoomSchemaLocationWorkaroundTest.groovy
@@ -233,7 +233,7 @@ class RoomSchemaLocationWorkaroundTest extends AbstractTest {
         assertMergedSchemaOutputsExist()
 
         and:
-        buildResult.output.contains("${RoomSchemaLocationWorkaround.class.simpleName} is only compatible with Kotlin Gradle plugin version 1.6.10 or higher (found ${kotlinVersion}).")
+        buildResult.output.contains("${RoomSchemaLocationWorkaround.class.simpleName} is only compatible with Kotlin Gradle plugin version 1.6.0 or higher (found ${kotlinVersion}).")
 
         where:
         kotlinVersion << [ "1.5.32" ].collect { VersionNumber.parse(it) }

--- a/src/test/groovy/org/gradle/android/RoomSchemaLocationWorkaroundTest.groovy
+++ b/src/test/groovy/org/gradle/android/RoomSchemaLocationWorkaroundTest.groovy
@@ -19,10 +19,6 @@ class RoomSchemaLocationWorkaroundTest extends AbstractTest {
 
     @Unroll
     def "schemas are generated into task-specific directory and are cacheable with kotlin and kapt workers enabled (Android #androidVersion) (Kotlin #kotlinVersion)"() {
-        def kotlinVersionNumber = VersionNumber.parse(kotlinVersion)
-        // There are kotlin module version errors when using older versions of kotlin with AGP 7.2.0+ in this configuration
-        Assume.assumeFalse(androidVersion >= VersionNumber.parse("7.2.0-alpha01") && kotlinVersionNumber < VersionNumber.parse("1.5.0"))
-
         SimpleAndroidApp.builder(temporaryFolder.root, cacheDir)
             .withAndroidVersion(androidVersion)
             .withKotlinVersion(VersionNumber.parse(kotlinVersion))
@@ -85,14 +81,6 @@ class RoomSchemaLocationWorkaroundTest extends AbstractTest {
 
     @Unroll
     def "schemas are generated into task-specific directory and are cacheable with kotlin and kapt workers disabled (Android #androidVersion) (Kotlin #kotlinVersion)"() {
-        def kotlinVersionNumber = VersionNumber.parse(kotlinVersion)
-        // There are kotlin module version errors when using older versions of kotlin with AGP 7.2.0+ in this configuration
-        Assume.assumeFalse(androidVersion >= VersionNumber.parse("7.2.0-alpha01") && kotlinVersionNumber < VersionNumber.parse("1.5.0"))
-        // Since 7.4.0-alpha09, some AGP libraries are compiled with a newer Kotlin Compiler.
-        // Builds using KGP < 1.6.0 and AGP 7.4.0-alpha09+ cause metadata incompatibilities.
-        // https://issuetracker.google.com/issues/241287607
-        Assume.assumeFalse(androidVersion >= VersionNumber.parse("7.4.0-alpha09") && kotlinVersionNumber < VersionNumber.parse("1.6.0"))
-
         SimpleAndroidApp.builder(temporaryFolder.root, cacheDir)
             .withAndroidVersion(androidVersion)
             .withKotlinVersion(VersionNumber.parse(kotlinVersion))
@@ -211,9 +199,9 @@ class RoomSchemaLocationWorkaroundTest extends AbstractTest {
 
     @Unroll
     def "workaround is not applied with older Kotlin plugin version (Kotlin #kotlinVersion)"() {
-        Assume.assumeTrue(TestVersions.getLatestVersionForAndroid("3.6") != null)
+        Assume.assumeTrue(TestVersions.getLatestVersionForAndroid("7.3.1") != null)
 
-        def androidVersion = TestVersions.getLatestVersionForAndroid("3.6")
+        def androidVersion = TestVersions.getLatestVersionForAndroid("7.3.1")
         SimpleAndroidApp.builder(temporaryFolder.root, cacheDir)
             .withAndroidVersion(androidVersion)
             .withKotlinVersion(kotlinVersion)
@@ -245,10 +233,10 @@ class RoomSchemaLocationWorkaroundTest extends AbstractTest {
         assertMergedSchemaOutputsExist()
 
         and:
-        buildResult.output.contains("${RoomSchemaLocationWorkaround.class.simpleName} is only compatible with Kotlin Gradle plugin version 1.3.70 or higher (found ${kotlinVersion}).")
+        buildResult.output.contains("${RoomSchemaLocationWorkaround.class.simpleName} is only compatible with Kotlin Gradle plugin version 1.6.10 or higher (found ${kotlinVersion}).")
 
         where:
-        kotlinVersion << [ "1.3.61", "1.3.50" ].collect { VersionNumber.parse(it) }
+        kotlinVersion << [ "1.5.32" ].collect { VersionNumber.parse(it) }
     }
 
     @Unroll
@@ -461,9 +449,6 @@ class RoomSchemaLocationWorkaroundTest extends AbstractTest {
     @Issue("https://github.com/gradle/android-cache-fix-gradle-plugin/issues/353")
     @Unroll
     def "does not error when tasks are eagerly created (Android #androidVersion) (Kotlin #kotlinVersion)"() {
-        def kotlinVersionNumber = VersionNumber.parse(kotlinVersion)
-        // There are kotlin module version errors when using older versions of kotlin with AGP 7.2.0+ in this configuration
-        Assume.assumeFalse(androidVersion >= VersionNumber.parse("7.2.0-alpha01") && kotlinVersionNumber < VersionNumber.parse("1.5.0"))
 
         SimpleAndroidApp.builder(temporaryFolder.root, cacheDir)
             .withAndroidVersion(androidVersion)

--- a/src/test/groovy/org/gradle/android/TestVersions.groovy
+++ b/src/test/groovy/org/gradle/android/TestVersions.groovy
@@ -40,7 +40,7 @@ class TestVersions {
         return minorVersions.collect { getLatestVersionForAndroid(it) }
     }
 
-    static List<String> supportedKotlinVersions = ["1.6.10"]
+    static List<String> supportedKotlinVersions = ["1.6.21"]
 
     static VersionNumber oldestSupportedKotlinVersion() {
         return VersionNumber.parse(supportedKotlinVersions.first())

--- a/src/test/groovy/org/gradle/android/TestVersions.groovy
+++ b/src/test/groovy/org/gradle/android/TestVersions.groovy
@@ -40,7 +40,7 @@ class TestVersions {
         return minorVersions.collect { getLatestVersionForAndroid(it) }
     }
 
-    static List<String> supportedKotlinVersions = ["1.5.32", "1.6.10"]
+    static List<String> supportedKotlinVersions = ["1.6.10"]
 
     static VersionNumber oldestSupportedKotlinVersion() {
         return VersionNumber.parse(supportedKotlinVersions.first())


### PR DESCRIPTION
Drop support for Kotlin 1.5.32 in the supported Kotlin test versions for the Android Cache Fix Plugin

1.5.32 is behind three minor versions of the current one(1.8.0). Additionally, newer AGP versions bring Kotlin dependencies with incompatible binary version of its metadata: https://issuetracker.google.com/issues/241287607.


This PR sets the `MINIMUM_KOTLIN_VERSION` to Kotlin 1.6.10 to the plugin. Previous minimum version (1.4.32) it was not included in the supported test versions of Kotlin and currently is not building when using AGP 7.

Removed the additional assertions on the tests targeting lower Kotlin versions and fixed test `workaround is not applied with older Kotlin plugin version (Kotlin #kotlinVersion)` to include latest AGP version. 

