### PR TITLE
Fix RoomWorkaround ignoring `KaptWithKotlincTask` for  Kotlin 1.8

### DIFF
--- a/src/main/groovy/org/gradle/android/workarounds/RoomSchemaLocationWorkaround.groovy
+++ b/src/main/groovy/org/gradle/android/workarounds/RoomSchemaLocationWorkaround.groovy
@@ -215,7 +215,11 @@ class RoomSchemaLocationWorkaround implements Workaround {
             }
 
             project.tasks.withType(kaptWithoutKotlincTaskClass).configureEach(configureKaptTask)
-            project.tasks.withType(kaptWithKotlincTaskClass).configureEach(configureKaptTask)
+            // Task KaptWithKotlincTask was removed in 1.8 because Kapt is always run via Gradle workers.
+            // https://github.com/JetBrains/kotlin/commit/b8b0b279ee2195ccbdce61e2365f123ee928532b
+            if (KOTLIN_VERSION < VersionNumber.parse("1.8.0")) {
+                project.tasks.withType(kaptWithKotlincTaskClass).configureEach(configureKaptTask)
+            }
 
             // Since we've added a new kapt-specific provider to the variant, disable the provider
             // used for the JavaCompile task.  This is not great, but there

--- a/src/test/groovy/org/gradle/android/TestVersions.groovy
+++ b/src/test/groovy/org/gradle/android/TestVersions.groovy
@@ -40,7 +40,7 @@ class TestVersions {
         return minorVersions.collect { getLatestVersionForAndroid(it) }
     }
 
-    static List<String> supportedKotlinVersions = ["1.6.21", "1.7.21"]
+    static List<String> supportedKotlinVersions = ["1.6.21", "1.7.21", "1.8.0"]
 
     static VersionNumber oldestSupportedKotlinVersion() {
         return VersionNumber.parse(supportedKotlinVersions.first())


### PR DESCRIPTION
Task `KaptWithKotlincTask` was removed in 1.8 because Kapt is always run via Gradle workers: https://github.com/JetBrains/kotlin/commit/b8b0b279ee2195ccbdce61e2365f123ee928532b

Added Kotlin 1.8.0 in Kotlin test supported versions for tests.

Closes #398 