### PR TITLE
Separating the processor dependency from the runtime dependency in Gradle Runner builds

### DIFF
--- a/src/test/groovy/org/gradle/android/SimpleAndroidApp.groovy
+++ b/src/test/groovy/org/gradle/android/SimpleAndroidApp.groovy
@@ -167,7 +167,8 @@ class SimpleAndroidApp {
             }
 
             dependencies {
-                ${roomLibraryIfEnabled}
+                ${roomRuntimeLibraryIfEnabled}
+                ${roomProcessorsIfEnabled}
                 ${kotlinDependenciesIfEnabled}
             }
 
@@ -195,10 +196,9 @@ class SimpleAndroidApp {
         """.stripIndent()
     }
 
-    private String getRoomLibraryIfEnabled() {
+    private String getRoomRuntimeLibraryIfEnabled() {
         return (roomConfiguration != RoomConfiguration.NO_LIBRARY) ? """
                 implementation "androidx.room:room-runtime:${ROOM_LIBRARY_VERSION}"
-                annotationProcessor "androidx.room:room-compiler:${ROOM_LIBRARY_VERSION}"
         """ : ""
     }
 
@@ -230,15 +230,15 @@ class SimpleAndroidApp {
 
     private String getKotlinDependenciesIfEnabled() {
         return kotlinEnabled ? """
-            ${kaptRoomDependencyIfEnabled}
             implementation "org.jetbrains.kotlin:kotlin-stdlib"
         """ : ""
     }
 
-    private String getKaptRoomDependencyIfEnabled() {
-        return (roomConfiguration != RoomConfiguration.NO_LIBRARY) ? """
-            kapt "androidx.room:room-compiler:${ROOM_LIBRARY_VERSION}"
-        """ : ""
+    private String getRoomProcessorsIfEnabled() {
+        return roomConfiguration != RoomConfiguration.NO_LIBRARY ?
+            kotlinEnabled ? """ kapt "androidx.room:room-compiler:${ROOM_LIBRARY_VERSION}" """
+                : """ annotationProcessor "androidx.room:room-compiler:${ROOM_LIBRARY_VERSION}" """
+            : """ """
     }
 
     private String getToolchainConfigurationIfEnabled() {


### PR DESCRIPTION
In the Gradle runner test builds, we were adding always the configuration `annotationProcessor "androidx.room:room-compiler`. This configuration is not incorrect, however, in real projects we either configure the `kapt` configuration or the `annotationProcessor` for the Room compiler.

This PR separates the runtime declaration from the processor one. This change doesn't affect the RoomWorkaround for non-Kotlin projects. 

PR **doesn't** have dependency with #408