### PR TITLE
Apply configuration new variants API only when Plugins are present

### DIFF
--- a/src/main/groovy/org/gradle/android/workarounds/room/androidvariants/ApplyAndroidVariants.groovy
+++ b/src/main/groovy/org/gradle/android/workarounds/room/androidvariants/ApplyAndroidVariants.groovy
@@ -34,6 +34,16 @@ class ApplyAndroidVariants {
     }
 
     private static void applyToAllAndroidVariantsWithNewVariantApi(Project project, ConfigureVariants configureVariants) {
+        project.plugins.withId("com.android.application") {
+            configureNewVariants(project, configureVariants)
+        }
+
+        project.plugins.withId("com.android.library") {
+            configureNewVariants(project, configureVariants)
+        }
+    }
+
+    private static configureNewVariants(Project project, ConfigureVariants configureVariants){
         def androidComponents = project.extensions.findByName("androidComponents")
         def selector = androidComponents.selector()
         androidComponents.onVariants(selector.all(), configureVariants.newVariantConfiguration)

--- a/src/test/groovy/org/gradle/android/PluginBlockTest.groovy
+++ b/src/test/groovy/org/gradle/android/PluginBlockTest.groovy
@@ -1,0 +1,54 @@
+package org.gradle.android
+
+import org.gradle.testkit.runner.TaskOutcome
+
+// AGP 7.4 surfaced issues with the Plugin block configuration https://github.com/gradle/android-cache-fix-gradle-plugin/issues/412
+// Current Gradle Runner tests are using buildscript block. This test covers the scenario of declaring the plugin in the
+// plugins { block of the root build.gradle for these use cases:
+// * Plugin apply by default
+// * Plugin is not applied
+@MultiVersionTest
+class PluginBlockTest extends AbstractTest {
+
+    def "project builds when plugin is defined in the Plugin block but is not applied"() {
+
+        def projectDir = temporaryFolder.newFolder()
+
+        SimpleAndroidApp.builder(projectDir, cacheDir)
+            .withKotlinVersion(TestVersions.latestSupportedKotlinVersion())
+            .withPluginsBlockEnabled()
+            .build()
+            .writeProject()
+
+        when:
+        def result = withGradleVersion(TestVersions.latestGradleVersion().version)
+            .withProjectDir(projectDir)
+            .withArguments("assembleDebug", "--stacktrace", "--configuration-cache")
+            .build()
+
+        then:
+        result.task(":library:assembleDebug").outcome == TaskOutcome.SUCCESS
+        result.task(":library:compileDebugLibraryResources").outcome == TaskOutcome.SUCCESS
+    }
+
+    def "project builds when plugin is defined in the Plugin block and is applied"() {
+
+        def projectDir = temporaryFolder.newFolder()
+
+        SimpleAndroidApp.builder(projectDir, cacheDir)
+            .withKotlinVersion(TestVersions.latestSupportedKotlinVersion())
+            .withPluginsBlockEnabledApplyingThePlugin()
+            .build()
+            .writeProject()
+
+        when:
+        def result = withGradleVersion(TestVersions.latestGradleVersion().version)
+            .withProjectDir(projectDir)
+            .withArguments("assembleDebug", "--stacktrace", "--configuration-cache")
+            .build()
+
+        then:
+        result.task(":library:assembleDebug").outcome == TaskOutcome.SUCCESS
+        result.task(":library:compileDebugLibraryResources").outcome == TaskOutcome.SUCCESS
+    }
+}

--- a/src/test/groovy/org/gradle/android/SimpleAndroidApp.groovy
+++ b/src/test/groovy/org/gradle/android/SimpleAndroidApp.groovy
@@ -149,13 +149,11 @@ class SimpleAndroidApp {
     }
 
     private String getPluginBlockConfiguration() {
-        if (pluginsBlockEnabled) {
-            return """
-                plugins{
-                    id 'org.gradle.android.cache-fix' version '$pluginVersion' $applyPluginInBlock
-                }
-            """.stripIndent()
-        } else ""
+        return pluginsBlockEnabled ? """
+                    plugins{
+                        id 'org.gradle.android.cache-fix' version '$pluginVersion' $applyPluginInBlock
+                    }
+                """.stripIndent() : ""
     }
 
     private String getApplyPluginInBlock() {
@@ -163,12 +161,9 @@ class SimpleAndroidApp {
     }
 
     private String getPluginBuildScriptClasspathConfiguration() {
-        if (!pluginsBlockEnabled) {
-            return """
+        return pluginsBlockEnabled ? "" : """
                 classpath "${pluginGroupId}:android-cache-fix-gradle-plugin:${pluginVersion}"
-
             """.stripIndent()
-        } else ""
     }
 
     static String getPluginVersion() {

--- a/src/test/groovy/org/gradle/android/SimpleAndroidApp.groovy
+++ b/src/test/groovy/org/gradle/android/SimpleAndroidApp.groovy
@@ -20,8 +20,10 @@ class SimpleAndroidApp {
     private final RoomConfiguration roomConfiguration
     private final String toolchainVersion
     private final JavaVersion sourceCompatibility
+    private final boolean pluginsBlockEnabled
+    private final boolean pluginAppliedInPluginBlock
 
-    private SimpleAndroidApp(File projectDir, File cacheDir, VersionNumber androidVersion, VersionNumber kotlinVersion, boolean dataBindingEnabled, boolean kotlinEnabled, boolean kaptWorkersEnabled, RoomConfiguration roomConfiguration, String toolchainVersion, JavaVersion sourceCompatibility) {
+    private SimpleAndroidApp(File projectDir, File cacheDir, VersionNumber androidVersion, VersionNumber kotlinVersion, boolean dataBindingEnabled, boolean kotlinEnabled, boolean kaptWorkersEnabled, RoomConfiguration roomConfiguration, String toolchainVersion, JavaVersion sourceCompatibility, boolean pluginsBlockEnabled, boolean pluginAppliedInPluginBlock) {
         this.dataBindingEnabled = dataBindingEnabled
         this.projectDir = projectDir
         this.cacheDir = cacheDir
@@ -32,6 +34,8 @@ class SimpleAndroidApp {
         this.roomConfiguration = roomConfiguration
         this.toolchainVersion = toolchainVersion
         this.sourceCompatibility = sourceCompatibility
+        this.pluginsBlockEnabled = pluginsBlockEnabled
+        this.pluginAppliedInPluginBlock = pluginAppliedInPluginBlock
     }
 
     def writeProject() {
@@ -44,6 +48,16 @@ class SimpleAndroidApp {
         def libraryActivity = 'LibraryActivity'
 
         file("settings.gradle") << """
+                pluginManagement {
+                    repositories {
+                        mavenCentral()
+                        gradlePluginPortal()
+                        google()
+                        maven {
+                            url = "${localRepo}"
+                        }
+                    }
+                }
                 buildCache {
                     local {
                         directory = "${cacheDir.absolutePath.replace(File.separatorChar, '/' as char)}"
@@ -62,10 +76,11 @@ class SimpleAndroidApp {
                     }
                     dependencies {
                         classpath ('com.android.tools.build:gradle:$androidVersion') { force = true }
-                        classpath "${pluginGroupId}:android-cache-fix-gradle-plugin:${pluginVersion}"
+                        ${pluginBuildScriptClasspathConfiguration}
                         ${kotlinPluginDependencyIfEnabled}
                     }
                 }
+                ${pluginBlockConfiguration}
             """.stripIndent()
         if (kotlinEnabled) {
             writeKotlinClass(library, libPackage, libraryActivity)
@@ -131,6 +146,29 @@ class SimpleAndroidApp {
             """.stripIndent()
 
         configureAndroidSdkHome()
+    }
+
+    private String getPluginBlockConfiguration() {
+        if (pluginsBlockEnabled) {
+            return """
+                plugins{
+                    id 'org.gradle.android.cache-fix' version '$pluginVersion' $applyPluginInBlock
+                }
+            """.stripIndent()
+        } else ""
+    }
+
+    private String getApplyPluginInBlock() {
+        return pluginAppliedInPluginBlock ? "" : " apply false "
+    }
+
+    private String getPluginBuildScriptClasspathConfiguration() {
+        if (!pluginsBlockEnabled) {
+            return """
+                classpath "${pluginGroupId}:android-cache-fix-gradle-plugin:${pluginVersion}"
+
+            """.stripIndent()
+        } else ""
     }
 
     static String getPluginVersion() {
@@ -524,6 +562,8 @@ class SimpleAndroidApp {
         boolean dataBindingEnabled = true
         boolean kotlinEnabled = true
         boolean kaptWorkersEnabled = true
+        boolean pluginsBlockEnabled = false
+        boolean pluginAppliedInPluginBlock = false
         RoomConfiguration roomConfiguration = RoomConfiguration.ROOM_EXTENSION
 
         VersionNumber androidVersion = TestVersions.latestAndroidVersionForCurrentJDK()
@@ -604,8 +644,19 @@ class SimpleAndroidApp {
             return this
         }
 
+        Builder withPluginsBlockEnabled() {
+            this.pluginsBlockEnabled = true
+            return this
+        }
+
+        Builder withPluginsBlockEnabledApplyingThePlugin() {
+            this.pluginsBlockEnabled = true
+            this.pluginAppliedInPluginBlock = true
+            return this
+        }
+
         SimpleAndroidApp build() {
-            return new SimpleAndroidApp(projectDir, cacheDir, androidVersion, kotlinVersion, dataBindingEnabled, kotlinEnabled, kaptWorkersEnabled, roomConfiguration, toolchainVersion, sourceCompatibility)
+            return new SimpleAndroidApp(projectDir, cacheDir, androidVersion, kotlinVersion, dataBindingEnabled, kotlinEnabled, kaptWorkersEnabled, roomConfiguration, toolchainVersion, sourceCompatibility, pluginsBlockEnabled, pluginAppliedInPluginBlock)
         }
     }
 }


### PR DESCRIPTION
Issue #412 describes the issue when using AGP 7.4 and the Plugin throws:
```
Failed to apply plugin 'org.gradle.android.cache-fix'.
> Cannot invoke method selector() on null object
```
This is caused when the plugin is configuring a project without Android plugins applied. 
I can reproduce the error when in the project `nowinandroid` I remove the `apply false` in the plugin definition. That means the rootProject is trying to retrieve the `androidComponents`:
```
 def androidComponents = project.extensions.findByName("androidComponents")
```
when they are not applied. This is a change in the AGP not reproducible in 7.3.1. 

Similar to the old implementation this PR only applies the configuration when a project contains the Android plugins.