### PR TITLE
Using base plugin for Room workaround

### DIFF
--- a/src/main/groovy/org/gradle/android/workarounds/room/androidvariants/ApplyAndroidVariants.groovy
+++ b/src/main/groovy/org/gradle/android/workarounds/room/androidvariants/ApplyAndroidVariants.groovy
@@ -34,11 +34,7 @@ class ApplyAndroidVariants {
     }
 
     private static void applyToAllAndroidVariantsWithNewVariantApi(Project project, ConfigureVariants configureVariants) {
-        project.plugins.withId("com.android.application") {
-            configureNewVariants(project, configureVariants)
-        }
-
-        project.plugins.withId("com.android.library") {
+        project.plugins.withId("com.android.base") {
             configureNewVariants(project, configureVariants)
         }
     }


### PR DESCRIPTION
Based on this discussion https://github.com/gradle/android-cache-fix-gradle-plugin/pull/414#discussion_r1070514914
We configure the AGP 7.4 variants with `project.plugins.withId("com.android.base") {` instead of checking for specific plugins like application/library.