### PR TITLE
Fix version assumption JDKImage

### DIFF
--- a/src/test/groovy/org/gradle/android/JdkImageWorkaroundTest.groovy
+++ b/src/test/groovy/org/gradle/android/JdkImageWorkaroundTest.groovy
@@ -186,7 +186,7 @@ class JdkImageWorkaroundTest extends AbstractTest {
 
     def "workaround is enabled when enabled via system property"() {
         def androidVersion = TestVersions.latestAndroidVersionForCurrentJDK()
-        Assume.assumeTrue(androidVersion >= VersionNumber.parse("7.1.0-alpha01")  && androidVersion < VersionNumber.parse("7.4.0-alpha07"))
+        Assume.assumeTrue(androidVersion >= VersionNumber.parse("7.1.0-alpha01"))
         def gradleVersion = TestVersions.latestSupportedGradleVersionFor(androidVersion)
         SimpleAndroidApp.builder(temporaryFolder.root, cacheDir)
             .withAndroidVersion(androidVersion)


### PR DESCRIPTION
#426, good catch @tylerbertrand 
Before
https://ge.solutions-team.gradle.com/s/tuyrjfxxl2rko/tests/overview#:testandroid8_0_0_beta01-0-org.gradle.android.jdkimageworkaroundtest-3-workaround-is-enabled-when-enabled-via-system-property-9

After
https://ge.solutions-team.gradle.com/s/zegdtyextlj46/tests/overview#:testandroid8_0_0_beta01-0-org.gradle.android.jdkimageworkaroundtest-3-workaround-is-enabled-when-enabled-via-system-property-9