### PR TITLE
Check if schema exists to avoid JavaCompileWorkaround issue

### DIFF
--- a/src/main/groovy/org/gradle/android/workarounds/room/JavaCompileWorkaround.groovy
+++ b/src/main/groovy/org/gradle/android/workarounds/room/JavaCompileWorkaround.groovy
@@ -116,13 +116,15 @@ class JavaCompileWorkaround extends AnnotationProcessorWorkaround<JavaCompilerRo
     }
 
     static void copyExistingSchemasToTaskSpecificTmpDir(FileOperations fileOperations, Provider<Directory> existingSchemaDir, JavaCompilerRoomSchemaLocationArgumentProvider provider) {
-        // Derive the variant directory from the command line provider it is configured with
-        def variantSpecificSchemaDir = provider.schemaLocationDir
+        if (existingSchemaDir.isPresent()) {
+            // Derive the variant directory from the command line provider it is configured with
+            def variantSpecificSchemaDir = provider.schemaLocationDir
 
-        // Populate the variant-specific temporary schema dir with the existing schemas
-        fileOperations.sync {
-            it.from existingSchemaDir
-            it.into variantSpecificSchemaDir
+            // Populate the variant-specific temporary schema dir with the existing schemas
+            fileOperations.sync {
+                it.from existingSchemaDir
+                it.into variantSpecificSchemaDir
+            }
         }
     }
 


### PR DESCRIPTION
After workaround extractions and 2.6.4, users reported #432 
This issue is reproducible when applying the plugin in modules without kapt or room implementation.

The extraction didn't verify if the schema was present like in version 2.6.3: https://github.com/gradle/android-cache-fix-gradle-plugin/blob/v2.6.3/src/main/groovy/org/gradle/android/workarounds/RoomSchemaLocationWorkaround.groovy#L259

This PR adds the check. Kapt workaround is not affected. 
Internal note: Why we don't have tests covering builds with this configuration?