### PR TITLE
Updating parameters used in gradle properties for the Kotlin daemon Simple app

### DIFF
--- a/src/test/groovy/org/gradle/android/SimpleAndroidApp.groovy
+++ b/src/test/groovy/org/gradle/android/SimpleAndroidApp.groovy
@@ -138,7 +138,7 @@ class SimpleAndroidApp {
 
         file("gradle.properties") << """
                 android.useAndroidX=true
-                org.gradle.jvmargs=-Xmx1536m -XX:+UseParallelGC -Dkotlin.daemon.jvm.options=-Xmx768m,-Xms256m,-XX:MaxMetaspaceSize=1g
+                org.gradle.jvmargs=-Xmx1536m -Dkotlin.daemon.jvm.options=-Xmx768m,-Xms256m
                 kapt.use.worker.api=${kaptWorkersEnabled}
                 android.experimental.enableSourceSetPathsMap=true
                 android.experimental.cacheCompileLibResources=true

--- a/src/test/groovy/org/gradle/android/SimpleAndroidApp.groovy
+++ b/src/test/groovy/org/gradle/android/SimpleAndroidApp.groovy
@@ -138,7 +138,7 @@ class SimpleAndroidApp {
 
         file("gradle.properties") << """
                 android.useAndroidX=true
-                org.gradle.jvmargs=-Xmx2048m -Dkotlin.daemon.jvm.options=-Xmx1500m
+                org.gradle.jvmargs=-Xmx1536m -XX:+UseParallelGC -Dkotlin.daemon.jvm.options=-Xmx768m,-Xms256m,-XX:MaxMetaspaceSize=1g
                 kapt.use.worker.api=${kaptWorkersEnabled}
                 android.experimental.enableSourceSetPathsMap=true
                 android.experimental.cacheCompileLibResources=true


### PR DESCRIPTION
During the CI builds of the KspWorkaround(#429), we noticed builds failing in the tests executed:
![Screenshot 2023-02-14 at 5 46 15 PM](https://user-images.githubusercontent.com/475733/218906374-76abacda-2d37-494c-96be-821761f02dcd.png)
Test failing showed flakiness in some of the executions:
![Screenshot 2023-02-14 at 5 48 16 PM](https://user-images.githubusercontent.com/475733/218906668-172a7155-7b91-4bb2-95c1-71a095951165.png)
Logs showed:
```
Gradle build daemon disappeared unexpectedly (it may have been killed or may have crashed)
```
This error happens at the level of the test, not in the Build containing the Gradle runner builds. 

At this point, we started monitoring more in detail the number of test executed for a given build: 
For instance, for AGP 7.3.1 we execute around 40 unit tests, some of those tests execute different builds using different Kotlin versions. This combination causes to run more than 55 builds per build invocation.  We enabled process tracking for the Kotlin processes and discovered that 6 Kotlin processes were created:
![Screenshot 2023-02-14 at 5 57 13 PM](https://user-images.githubusercontent.com/475733/218907737-087c53b3-6591-4f16-a1fa-5bd6d6858630.png)
We are creating one Kotlin process for each Kotlin version, additionally some of the tests use different Gradle versions, explaining why we have 6 Kotlin processes.


The resources at the GHA container are limited 7GB, meaning that the container is killing the Gradle daemons because the pressure of the different processes. After some research, we ended up configuring the parameters of the Kotlin daemon limiting the heap memory allocation.
This PR includes the new configuration assuming that the max limit of Kotlin processes is 6 and satisfying the next formula:
  
```
(Kotlin Process * 6) + (Gradle Daemon * 2) +(Gradle Daemon(container)) + Test process < 7 GB
```


With this approach, we are reducing the number of total builds to 380 per commit. Before, we were incresing up to 524 builds because the retry, additionally the flakyness dissapear.

