### PR TITLE
Update Kotlin test version 1.8.10

### DIFF
--- a/src/test/groovy/org/gradle/android/TestVersions.groovy
+++ b/src/test/groovy/org/gradle/android/TestVersions.groovy
@@ -40,7 +40,7 @@ class TestVersions {
         return minorVersions.collect { getLatestVersionForAndroid(it) }
     }
 
-    static List<String> supportedKotlinVersions = ["1.6.21", "1.7.21", "1.8.0"]
+    static List<String> supportedKotlinVersions = ["1.6.21", "1.7.21", "1.8.10"]
 
     static VersionNumber latestSupportedKotlinVersion() {
         return VersionNumber.parse(supportedKotlinVersions.last())


### PR DESCRIPTION
Updating the Kotlin version used for Tests. 
This is required for the `KspWorkaround` that includes the pair <Kotlin Version, Ksp Version>