### PR TITLE
Use temurin instead of adopt java distribution

### DIFF
--- a/.github/workflows/build-verification.yml
+++ b/.github/workflows/build-verification.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           java-version: 11
-          distribution: 'adopt'
+          distribution: 'temurin'
       - name: Set up Gradle
         uses: gradle/gradle-build-action@v2
       - name: Run sanityCheck
@@ -44,7 +44,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           java-version: 11
-          distribution: 'adopt'
+          distribution: 'temurin'
       - name: Set up Gradle
         uses: gradle/gradle-build-action@v2
       - name: Run unit tests
@@ -87,12 +87,12 @@ jobs:
         uses: actions/setup-java@v3
         with:
           java-version: 11
-          distribution: 'adopt'
+          distribution: 'temurin'
       - name: Set up Java 17
         uses: actions/setup-java@v3
         with:
           java-version: 17
-          distribution: 'adopt'
+          distribution: 'temurin'
       - name: Set up Gradle
         uses: gradle/gradle-build-action@v2
       - name: Run integration tests

--- a/.github/workflows/wrapper-upgrade-execution.yml
+++ b/.github/workflows/wrapper-upgrade-execution.yml
@@ -28,7 +28,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           java-version: '11'
-          distribution: 'adopt'
+          distribution: 'temurin'
       - name: Set up Gradle
         uses: gradle/gradle-build-action@v2
       - name: Upgrade Wrappers


### PR DESCRIPTION
As per note in the https://github.com/actions/setup-java#supported-distributions section adopt openjdk was moved to eclipse temurin and it is advised to update