### PR TITLE
Enable PTS

### DIFF
--- a/.github/workflows/build-verification.yml
+++ b/.github/workflows/build-verification.yml
@@ -51,6 +51,7 @@ jobs:
         run: ./gradlew test -x signPluginMavenPublication -x signAndroidCacheFixPluginPluginMarkerMavenPublication
         env:
           GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GE_SOLUTIONS_ACCESS_TOKEN }}
+          ORG_GRADLE_PROJECT_isPTSEnabled: ${{ github.ref_name != 'main' }}
 
   android_version_tests:
     name: Android version tests
@@ -99,3 +100,4 @@ jobs:
         run: ./gradlew testAndroid${{ matrix.versions }} -x signPluginMavenPublication -x signAndroidCacheFixPluginPluginMarkerMavenPublication
         env:
           GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GE_SOLUTIONS_ACCESS_TOKEN }}
+          ORG_GRADLE_PROJECT_isPTSEnabled: ${{ github.ref_name != 'main' }}

--- a/build.gradle
+++ b/build.gradle
@@ -107,6 +107,9 @@ tasks.withType(Test).configureEach {
         maxRetries = isCI ? 1 : 0
         maxFailures = 20
     }
+    predictiveSelection {
+        enabled = providers.gradleProperty("isPTSEnabled").map { it != 'false' } .orElse(false)
+    }
 }
 
 // Generate a test task for each Android version and run the tests annotated with the MultiVersionTest category

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,3 +4,5 @@ org.gradle.parallel=true
 org.gradle.caching=true
 org.gradle.unsafe.configuration-cache=true
 org.gradle.jvmargs=-Duser.language=en -Duser.country=US -Dfile.encoding=UTF-8
+
+isPTSEnabled=false


### PR DESCRIPTION
Enable PTS unless `isPTSEnabled` property is explicitly set to false
* If `isPTSEnabled` property exists but has not been set, or has been set to `true`, PTS will be enabled.
* If `isPTSEnabled` property has been explicitly set to `false`, PTS will be disabled.
* With this PR, PTS will be disabled by default, as `isPTSEnabled` has been set to `false`

Enable PTS in CI if not running against main