### PR TITLE
Verify room-processor is included before adding the ArgumentProvider

### DIFF
--- a/src/main/groovy/org/gradle/android/workarounds/room/KaptWorkaround.groovy
+++ b/src/main/groovy/org/gradle/android/workarounds/room/KaptWorkaround.groovy
@@ -39,18 +39,22 @@ class KaptWorkaround extends AnnotationProcessorWorkaround<KaptRoomSchemaLocatio
             @Override
             Closure<?> getOldVariantConfiguration() {
                 return { variant ->
-                    def variantSpecificSchemaDir = project.objects.directoryProperty()
-                    variantSpecificSchemaDir.set(androidVariantProvider.getVariantSpecificSchemaDir(project, "kapt${variant.name.capitalize()}Kotlin"))
-                    variant.javaCompileOptions.annotationProcessorOptions.compilerArgumentProviders.add(new KaptRoomSchemaLocationArgumentProvider(roomExtension.schemaLocationDir, variantSpecificSchemaDir))
+                    if (kaptContainsRoom()) {
+                        def variantSpecificSchemaDir = project.objects.directoryProperty()
+                        variantSpecificSchemaDir.set(androidVariantProvider.getVariantSpecificSchemaDir(project, "kapt${variant.name.capitalize()}Kotlin"))
+                        variant.javaCompileOptions.annotationProcessorOptions.compilerArgumentProviders.add(new KaptRoomSchemaLocationArgumentProvider(roomExtension.schemaLocationDir, variantSpecificSchemaDir))
+                    }
                 }
             }
 
             @Override
             Closure<?> getNewVariantConfiguration() {
                 return { variant ->
-                    def variantSpecificSchemaDir = project.objects.directoryProperty()
-                    variantSpecificSchemaDir.set(androidVariantProvider.getVariantSpecificSchemaDir(project, "kapt${variant.name.capitalize()}Kotlin"))
-                    variant.javaCompilation.annotationProcessor.argumentProviders.add(new KaptRoomSchemaLocationArgumentProvider(roomExtension.schemaLocationDir, variantSpecificSchemaDir))
+                    if (kaptContainsRoom()) {
+                        def variantSpecificSchemaDir = project.objects.directoryProperty()
+                        variantSpecificSchemaDir.set(androidVariantProvider.getVariantSpecificSchemaDir(project, "kapt${variant.name.capitalize()}Kotlin"))
+                        variant.javaCompilation.annotationProcessor.argumentProviders.add(new KaptRoomSchemaLocationArgumentProvider(roomExtension.schemaLocationDir, variantSpecificSchemaDir))
+                    }
                 }
             }
         })
@@ -143,4 +147,11 @@ class KaptWorkaround extends AnnotationProcessorWorkaround<KaptRoomSchemaLocatio
             throw new RuntimeException("Field '${fieldName}' not found")
         }
     }
+
+    // Before adding the ArgumentProvider, we need to verify that the room-processor is applied in the kapt configuration
+    private boolean kaptContainsRoom() {
+        return project.configurations.named("kapt").get().dependencies.name
+            .findAll { it == "room-compiler" }.size() > 0
+    }
+
 }


### PR DESCRIPTION
Issue #446 
Kapt workaround always adds the argument provider for the variants of the module using kapt plugin independently if they are using the room processor. 
This PR adds the check to avoid the configuration of the argument provider if `room-processor` is not set. 