### PR TITLE
Signing only required in CI when taskGraph includes publishingPlugins

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,9 +23,9 @@ repositories {
 
 dependencies {
     def versions = [
-        'agp'          : '7.3.1',
+        'agp': '7.3.1',
         'sdkBuildTools': '30.0.4',
-        'spock'        : '2.3-groovy-3.0',
+        'spock': '2.3-groovy-3.0',
     ]
 
     compileOnly gradleApi()
@@ -108,7 +108,7 @@ tasks.withType(Test).configureEach {
         maxFailures = 20
     }
     predictiveSelection {
-        enabled = providers.gradleProperty("isPTSEnabled").map { it != 'false' }.orElse(false)
+        enabled = providers.gradleProperty("isPTSEnabled").map { it != 'false' } .orElse(false)
     }
 }
 
@@ -154,8 +154,8 @@ tasks.withType(ValidatePlugins).configureEach {
 }
 
 signing {
-    // Require publications to be signed on CI and publishing task included in the TaskGraph
-    required { isCI && gradle.taskGraph.hasTask(":publishPlugins") }
+    // Require publications when :publishPlugins task included in the TaskGraph
+    required { gradle.taskGraph.hasTask(":publishPlugins") }
 
     useInMemoryPgpKeys(
         providers.environmentVariable("PGP_SIGNING_KEY").orNull,

--- a/build.gradle
+++ b/build.gradle
@@ -23,9 +23,9 @@ repositories {
 
 dependencies {
     def versions = [
-        'agp': '7.3.1',
+        'agp'          : '7.3.1',
         'sdkBuildTools': '30.0.4',
-        'spock': '2.3-groovy-3.0',
+        'spock'        : '2.3-groovy-3.0',
     ]
 
     compileOnly gradleApi()
@@ -108,7 +108,7 @@ tasks.withType(Test).configureEach {
         maxFailures = 20
     }
     predictiveSelection {
-        enabled = providers.gradleProperty("isPTSEnabled").map { it != 'false' } .orElse(false)
+        enabled = providers.gradleProperty("isPTSEnabled").map { it != 'false' }.orElse(false)
     }
 }
 
@@ -154,8 +154,8 @@ tasks.withType(ValidatePlugins).configureEach {
 }
 
 signing {
-    // Require publications to be signed on CI. Otherwise, publication will be signed only if keys are provided.
-    required isCI
+    // Require publications to be signed on CI and publishing task included in the TaskGraph
+    required { isCI && gradle.taskGraph.hasTask(":publishPlugins") }
 
     useInMemoryPgpKeys(
         providers.environmentVariable("PGP_SIGNING_KEY").orNull,

--- a/build.gradle
+++ b/build.gradle
@@ -154,7 +154,7 @@ tasks.withType(ValidatePlugins).configureEach {
 }
 
 signing {
-    // Require publications when :publishPlugins task included in the TaskGraph
+    // Require publications to be signed when :publishPlugins task is included in the TaskGraph
     required { gradle.taskGraph.hasTask(":publishPlugins") }
 
     useInMemoryPgpKeys(


### PR DESCRIPTION
Closes #478 

### Tests
#### Gradle 8.0.2
- [x]  CI passing https://github.com/gradle/android-cache-fix-gradle-plugin/actions/runs/4503448211 and https://github.com/gradle/android-cache-fix-gradle-plugin/actions/runs/4503449449
- [x] Local publish to maven local: https://ge.solutions-team.gradle.com/s/4wb4vqsnvsjd4
- [x] Local, project using the published version [https://ge.solutions-team.gradle.com/s/ejdoyjlfglxxi/build-dependencies?focusedDependency=W[…]bMCwwLFs3OV1dXQ&toggled=W1swXSxbMCwwXSxbMCwwLFs3OV1dXQ](https://ge.solutions-team.gradle.com/s/ejdoyjlfglxxi/build-dependencies?focusedDependency=WzAsMCw3OSxbMCwwLFs3OV1dXQ&toggled=W1swXSxbMCwwXSxbMCwwLFs3OV1dXQ)
- [x] Published plugin in staging  https://github.com/gradle/ge-solutions/actions/runs/4506089290/jobs/7932503309
 
#### Gradle 8.1
- [x] CI passing: https://github.com/gradle/android-cache-fix-gradle-plugin/actions/runs/4504797075 and https://github.com/gradle/android-cache-fix-gradle-plugin/actions/runs/4504797073
- [x] Local publish to maven local: https://ge.solutions-team.gradle.com/s/uq3yh77pjzspo
- [x] Local, project using the published version: https://ge.solutions-team.gradle.com/s/afasttfzu35qi/build-dependencies?focusedDependency=WzAsMCw4MixbMCwwLFs4Ml1dXQ&toggled=W1swXSxbMCwwXV0
- [x] Published plugin in staging: https://github.com/gradle/ge-solutions/actions/runs/4505505528
