### PR TITLE
Use relative path on `room.schemaLocation` annotation processor argument

### DIFF
--- a/src/main/groovy/org/gradle/android/workarounds/room/JavaCompileWorkaround.groovy
+++ b/src/main/groovy/org/gradle/android/workarounds/room/JavaCompileWorkaround.groovy
@@ -47,7 +47,7 @@ class JavaCompileWorkaround extends AnnotationProcessorWorkaround<JavaCompilerRo
                     // Add a command line argument provider to the compile task argument providers
                     variant.javaCompileProvider.configure { JavaCompile task ->
                         task.options.compilerArgumentProviders.add(
-                            new JavaCompilerRoomSchemaLocationArgumentProvider(roomExtension.schemaLocationDir, variantSpecificSchemaDir)
+                            new JavaCompilerRoomSchemaLocationArgumentProvider(project,  roomExtension.schemaLocationDir, variantSpecificSchemaDir)
                         )
                     }
 
@@ -66,7 +66,7 @@ class JavaCompileWorkaround extends AnnotationProcessorWorkaround<JavaCompilerRo
                     variantSpecificSchemaDir.set(androidVariantProvider.getVariantSpecificSchemaDir(project, "compile${variant.name.capitalize()}JavaWithJavac"))
 
                     variant.javaCompilation.annotationProcessor.argumentProviders.add(
-                        new JavaCompilerRoomSchemaLocationArgumentProvider(roomExtension.schemaLocationDir, variantSpecificSchemaDir)
+                        new JavaCompilerRoomSchemaLocationArgumentProvider(project, roomExtension.schemaLocationDir, variantSpecificSchemaDir)
                     )
                 }
             }

--- a/src/main/groovy/org/gradle/android/workarounds/room/KaptWorkaround.groovy
+++ b/src/main/groovy/org/gradle/android/workarounds/room/KaptWorkaround.groovy
@@ -41,7 +41,7 @@ class KaptWorkaround extends AnnotationProcessorWorkaround<KaptRoomSchemaLocatio
                 return { variant ->
                     def variantSpecificSchemaDir = project.objects.directoryProperty()
                     variantSpecificSchemaDir.set(androidVariantProvider.getVariantSpecificSchemaDir(project, "kapt${variant.name.capitalize()}Kotlin"))
-                    variant.javaCompileOptions.annotationProcessorOptions.compilerArgumentProviders.add(new KaptRoomSchemaLocationArgumentProvider(roomExtension.schemaLocationDir, variantSpecificSchemaDir))
+                    variant.javaCompileOptions.annotationProcessorOptions.compilerArgumentProviders.add(new KaptRoomSchemaLocationArgumentProvider(project, roomExtension.schemaLocationDir, variantSpecificSchemaDir))
                 }
             }
 
@@ -50,7 +50,7 @@ class KaptWorkaround extends AnnotationProcessorWorkaround<KaptRoomSchemaLocatio
                 return { variant ->
                     def variantSpecificSchemaDir = project.objects.directoryProperty()
                     variantSpecificSchemaDir.set(androidVariantProvider.getVariantSpecificSchemaDir(project, "kapt${variant.name.capitalize()}Kotlin"))
-                    variant.javaCompilation.annotationProcessor.argumentProviders.add(new KaptRoomSchemaLocationArgumentProvider(roomExtension.schemaLocationDir, variantSpecificSchemaDir))
+                    variant.javaCompilation.annotationProcessor.argumentProviders.add(new KaptRoomSchemaLocationArgumentProvider(project, roomExtension.schemaLocationDir, variantSpecificSchemaDir))
                 }
             }
         })

--- a/src/main/groovy/org/gradle/android/workarounds/room/KspWorkaround.groovy
+++ b/src/main/groovy/org/gradle/android/workarounds/room/KspWorkaround.groovy
@@ -37,7 +37,7 @@ class KspWorkaround extends AnnotationProcessorWorkaround<KspRoomSchemaLocationA
         def schemaLocationDir = roomExtension.schemaLocationDir
 
         def variantSpecificSchemaDir = project.objects.directoryProperty()
-        KspRoomSchemaLocationArgumentProvider provider = new KspRoomSchemaLocationArgumentProvider(roomExtension.schemaLocationDir, variantSpecificSchemaDir)
+        KspRoomSchemaLocationArgumentProvider provider = new KspRoomSchemaLocationArgumentProvider(project, roomExtension.schemaLocationDir, variantSpecificSchemaDir)
         variantSpecificSchemaDir.set(androidVariantProvider.getVariantSpecificSchemaDir(project, "${task.name}"))
         task.commandLineArgumentProviders.add(provider)
 

--- a/src/main/groovy/org/gradle/android/workarounds/room/argumentprovider/JavaCompilerRoomSchemaLocationArgumentProvider.groovy
+++ b/src/main/groovy/org/gradle/android/workarounds/room/argumentprovider/JavaCompilerRoomSchemaLocationArgumentProvider.groovy
@@ -1,12 +1,13 @@
 package org.gradle.android.workarounds.room.argumentprovider
 
 import groovy.transform.CompileStatic
+import org.gradle.api.Project
 import org.gradle.api.file.Directory
 import org.gradle.api.provider.Provider
 
 @CompileStatic
 class JavaCompilerRoomSchemaLocationArgumentProvider extends RoomSchemaLocationArgumentProvider {
-    JavaCompilerRoomSchemaLocationArgumentProvider(Provider<Directory> configuredSchemaLocationDir, Provider<Directory> schemaLocationDir) {
-        super(configuredSchemaLocationDir, schemaLocationDir)
+    JavaCompilerRoomSchemaLocationArgumentProvider(Project project, Provider<Directory> configuredSchemaLocationDir, Provider<Directory> schemaLocationDir) {
+        super(project, configuredSchemaLocationDir, schemaLocationDir)
     }
 }

--- a/src/main/groovy/org/gradle/android/workarounds/room/argumentprovider/KaptRoomSchemaLocationArgumentProvider.groovy
+++ b/src/main/groovy/org/gradle/android/workarounds/room/argumentprovider/KaptRoomSchemaLocationArgumentProvider.groovy
@@ -1,6 +1,7 @@
 package org.gradle.android.workarounds.room.argumentprovider
 
 import groovy.transform.CompileStatic
+import org.gradle.api.Project
 import org.gradle.api.file.Directory
 import org.gradle.api.provider.Provider
 
@@ -8,13 +9,13 @@ import org.gradle.api.provider.Provider
 class KaptRoomSchemaLocationArgumentProvider extends RoomSchemaLocationArgumentProvider {
     private Provider<Directory> temporarySchemaLocationDir
 
-    KaptRoomSchemaLocationArgumentProvider(Provider<Directory> configuredSchemaLocationDir, Provider<Directory> schemaLocationDir) {
-        super(configuredSchemaLocationDir, schemaLocationDir)
+    KaptRoomSchemaLocationArgumentProvider(Project project, Provider<Directory> configuredSchemaLocationDir, Provider<Directory> schemaLocationDir) {
+        super(project, configuredSchemaLocationDir, schemaLocationDir)
         this.temporarySchemaLocationDir = schemaLocationDir.map {it.dir("../${it.asFile.name}Temp") }
     }
 
     @Override
     protected String getSchemaLocationPath() {
-        return temporarySchemaLocationDir.get().asFile.absolutePath
+        return projectDir.relativePath(temporarySchemaLocationDir.get().asFile)
     }
 }

--- a/src/main/groovy/org/gradle/android/workarounds/room/argumentprovider/KspRoomSchemaLocationArgumentProvider.groovy
+++ b/src/main/groovy/org/gradle/android/workarounds/room/argumentprovider/KspRoomSchemaLocationArgumentProvider.groovy
@@ -1,5 +1,6 @@
 package org.gradle.android.workarounds.room.argumentprovider
 
+import org.gradle.api.Project
 import org.gradle.api.file.Directory
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.Internal
@@ -7,13 +8,13 @@ import org.gradle.api.tasks.Internal
 class KspRoomSchemaLocationArgumentProvider extends RoomSchemaLocationArgumentProvider {
     @Internal Provider<Directory> temporarySchemaLocationDir
 
-    KspRoomSchemaLocationArgumentProvider(Provider<Directory> configuredSchemaLocationDir, Provider<Directory> schemaLocationDir) {
-        super(configuredSchemaLocationDir, schemaLocationDir)
+    KspRoomSchemaLocationArgumentProvider(Project project, Provider<Directory> configuredSchemaLocationDir, Provider<Directory> schemaLocationDir) {
+        super(project, configuredSchemaLocationDir, schemaLocationDir)
         this.temporarySchemaLocationDir = schemaLocationDir.map { it.dir("../${it.asFile.name}Temp") }
     }
 
     @Override
     protected String getSchemaLocationPath() {
-        return temporarySchemaLocationDir.get().asFile.absolutePath
+        return projectDir.relativePath(temporarySchemaLocationDir.get().asFile)
     }
 }

--- a/src/main/groovy/org/gradle/android/workarounds/room/argumentprovider/RoomSchemaLocationArgumentProvider.groovy
+++ b/src/main/groovy/org/gradle/android/workarounds/room/argumentprovider/RoomSchemaLocationArgumentProvider.groovy
@@ -2,6 +2,7 @@ package org.gradle.android.workarounds.room.argumentprovider
 
 import groovy.transform.CompileStatic
 import org.gradle.android.workarounds.RoomSchemaLocationWorkaround
+import org.gradle.api.Project
 import org.gradle.api.file.Directory
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.Internal
@@ -11,20 +12,25 @@ import org.gradle.process.CommandLineArgumentProvider
 
 @CompileStatic
 abstract class RoomSchemaLocationArgumentProvider implements CommandLineArgumentProvider {
+
+    @Internal
+    final File projectDir;
+
     @Internal
     final Provider<Directory> configuredSchemaLocationDir
 
     @Internal
     final Provider<Directory> schemaLocationDir
 
-    RoomSchemaLocationArgumentProvider(Provider<Directory> configuredSchemaLocationDir, Provider<Directory> schemaLocationDir) {
+    RoomSchemaLocationArgumentProvider(Project project, Provider<Directory> configuredSchemaLocationDir, Provider<Directory> schemaLocationDir) {
+        this.projectDir = project.projectDir
         this.configuredSchemaLocationDir = configuredSchemaLocationDir
         this.schemaLocationDir = schemaLocationDir
     }
 
     @Internal
     protected String getSchemaLocationPath() {
-        return schemaLocationDir.get().asFile.absolutePath
+        return projectDir.relativePath(schemaLocationDir.get().asFile)
     }
 
     @Override


### PR DESCRIPTION
Researching some cache misses we found our that `ksp` tasks are not relocatable (miss if build on another absolute path) when using `room` compiler.

Further research comparing scans revealed that the cache mismatch happens because there is a difference in the `pluginOptions.$0.asTaskInputArgs` input property:
![image](https://user-images.githubusercontent.com/513566/229817591-eadae84d-7491-4379-ba25-5c0d7a18b7b1.png)

Digging deeper on the property, it's revealed that `RoomSchemaLocationArgumentProvider` is adding absolute paths to the schema location direction in the annotation processor params:
```
pluginOptions.$0.asTaskInputArgs: {com.google.devtools.ksp.symbol-processing.incremental=true, com.google.devtools.ksp.symbol-processing.incrementalLog=false, com.google.devtools.ksp.symbol-processing.allWarningsAsErrors=false, com.google.devtools.ksp.symbol-processing.returnOkOnError=true, com.google.devtools.ksp.symbol-processing.apoption.0=glovo.featureToggles.enumName=com.glovoapp.payments.PaymentsFeatureToggles, com.google.devtools.ksp.symbol-processing.apoption.1=glovo.featureToggles.includeDependencies=false, com.google.devtools.ksp.symbol-processing.apoption.2=glovo.featureToggles.hiltSupport=true, com.google.devtools.ksp.symbol-processing.apoption.3=room.schemaLocation=/Users/gmazzola/Documents/glovo-customer-android/payments/build/roomSchemas/kspDebugKotlinTemp, com.google.devtools.ksp.symbol-processing.excludedProcessors=, com.google.devtools.ksp.symbol-processing.mapAnnotationArgumentsInJava=false}
```

Looking at `com.google.devtools.ksp.symbol-processing.apoption.3=room.schemaLocation=/Users/gmazzola/Documents/glovo-customer-android/payments/build/roomSchemas/kspDebugKotlinTemp` we observe an absolute path, which invalidates the whole propose of the `KspWorkaround`.

I did not test with KAPT, but it seems it's also affected by the issue.

## Fix: use relative paths instead
The code was modified to provide a relative path to the project instead.
