### PR TITLE
Add release notes to published plugin description and read version file using CC-comaptible api

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,8 +13,10 @@ plugins {
 
 group = 'org.gradle.android'
 version = layout.projectDirectory.file("release/version.txt").asFile.text.trim()
+description = 'A Gradle plugin to fix Android caching problems'
 
 def isCI = (System.getenv('CI') ?: 'false').toBoolean()
+def releaseNotes = releaseNotes()
 
 repositories {
     google()
@@ -67,7 +69,7 @@ gradlePlugin {
         androidCacheFixPlugin {
             id = 'org.gradle.android.cache-fix'
             displayName = 'Gradle Android cache fix plugin'
-            description = 'Gradle plugin to fix Android caching problems'
+            description = releaseNotes.get()
             implementationClass = 'org.gradle.android.AndroidCacheFixPlugin'
             tags.addAll('android', 'cache', 'fix')
         }
@@ -172,7 +174,7 @@ githubRelease {
    prerelease = false
    overwrite = false
    generateReleaseNotes = false
-   body = layout.projectDirectory.file("release/changes.md").asFile.text.trim()
+   body = releaseNotes
    targetCommitish = "main"
 }
 
@@ -196,4 +198,9 @@ def gitHubReleaseName() {
 
 def gitReleaseTag() {
     return "v${version}"
+}
+
+def releaseNotes() {
+    def releaseNotesFile = layout.projectDirectory.file('release/changes.md')
+    return providers.fileContents(releaseNotesFile).asText.map { it -> it.trim() }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -11,12 +11,13 @@ plugins {
     id 'org.gradle.wrapper-upgrade' version '0.11.1'
 }
 
-group = 'org.gradle.android'
-version = layout.projectDirectory.file("release/version.txt").asFile.text.trim()
-description = 'A Gradle plugin to fix Android caching problems'
-
-def isCI = (System.getenv('CI') ?: 'false').toBoolean()
+def releaseVersion = releaseVersion()
 def releaseNotes = releaseNotes()
+def isCI = (System.getenv('CI') ?: 'false').toBoolean()
+
+group = 'org.gradle.android'
+version = releaseVersion
+description = 'A Gradle plugin to fix Android caching problems'
 
 repositories {
     google()
@@ -166,22 +167,22 @@ signing {
 }
 
 githubRelease {
-   token = System.getenv("ANDROID_CACHE_FIX_PLUGIN_GIT_TOKEN") ?: ''
-   owner = "gradle"
-   repo = "android-cache-fix-gradle-plugin"
-   releaseName = gitHubReleaseName()
-   tagName = gitReleaseTag()
-   prerelease = false
-   overwrite = false
-   generateReleaseNotes = false
-   body = releaseNotes
-   targetCommitish = "main"
+    token = System.getenv("ANDROID_CACHE_FIX_PLUGIN_GIT_TOKEN") ?: ''
+    owner = "gradle"
+    repo = "android-cache-fix-gradle-plugin"
+    releaseName = releaseVersion
+    tagName = releaseVersion.map { "v$it" }
+    prerelease = false
+    overwrite = false
+    generateReleaseNotes = false
+    body = releaseNotes
+    targetCommitish = "main"
 }
 
 def createReleaseTag = tasks.register('createReleaseTag', CreateGitTag) {
     // Ensure tag is created only after successful publishing
     mustRunAfter('publishPlugins')
-    tagName = gitReleaseTag()
+    tagName = githubRelease.tagName.map { it.toString() }
 }
 
 tasks.named("githubRelease").configure {
@@ -192,12 +193,9 @@ tasks.withType(Sign).configureEach {
     notCompatibleWithConfigurationCache("$name task does not support configuration caching")
 }
 
-def gitHubReleaseName() {
-    return version.toString()
-}
-
-def gitReleaseTag() {
-    return "v${version}"
+def releaseVersion() {
+    def releaseVersionFile = layout.projectDirectory.file('release/version.txt')
+    return providers.fileContents(releaseVersionFile).asText.map { it -> it.trim() }
 }
 
 def releaseNotes() {


### PR DESCRIPTION
Resolves #437 

### Add release notes to published plugin description

* This allows users to view release notes from the plugin portal and gives them an idea of what will be gained by updating to that version
* Leverage providers.fileContents() to support configuration caching when reading release notes file

### Use configuration-cache-compatible Provider API to read version file
* Use configuration-cache-compatible Provider.fileContents() to read version file
* Inline gitReleaseTag()
* Use githubRelease extension object to get tagName value for createReleaseTag task
* Correct githubRelease extension block indent from 3 spaces to 4