### PR TITLE
Kotlin DSL shown by default in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,27 +36,6 @@ If you discover an issue related to the Android Gradle Plugin, please file an is
 
 This plugin should be applied anywhere the `com.android.application` or `com.android.library` plugins are applied. We recommend adding the plugin to your project's [conventions plugin](https://docs.gradle.org/current/samples/sample_convention_plugins.html).
 
-<details>
-<summary>Groovy</summary>
-<br>
-
-```groovy
-// in build.grade for convention plugin build
-dependencies {
-    // ...
-    implementation("org.gradle.android.cache-fix:org.gradle.android.cache-fix.gradle.plugin:2.7.0")
-    // ...
-}
-
-// in com.myconventions.build.gradle
-plugins {
-    id 'com.android.application' // or 'com.android.library'
-    // Add this next line to your existing convention plugin.
-    id 'org.gradle.android.cache-fix'
-}
-```
-
-</details>
 <details open>
 <summary>Kotlin</summary>
 <br>
@@ -78,8 +57,47 @@ plugins {
 ```
 </details>
 
+<details>
+<summary>Groovy</summary>
+<br>
+
+```groovy
+// in build.grade for convention plugin build
+dependencies {
+    // ...
+    implementation("org.gradle.android.cache-fix:org.gradle.android.cache-fix.gradle.plugin:2.7.0")
+    // ...
+}
+
+// in com.myconventions.build.gradle
+plugins {
+    id 'com.android.application' // or 'com.android.library'
+    // Add this next line to your existing convention plugin.
+    id 'org.gradle.android.cache-fix'
+}
+```
+
+</details>
+
 If you are not using convention plugins and would like a quick way of testing the plugin you can alternatively place it in the root project's build.gradle (change '2.7.0' to the latest version of the cache fix plugin
 [here](https://plugins.gradle.org/plugin/org.gradle.android.cache-fix)). We discourage this approach because it uses [cross project configuration](https://docs.gradle.org/current/userguide/sharing_build_logic_between_subprojects.html#sec:convention_plugins_vs_cross_configuration).
+
+<details open>
+<summary>Kotlin</summary>
+<br>
+
+```kotlin
+plugins {
+    id("org.gradle.android.cache-fix") version "2.7.0" apply false
+}
+
+subprojects {
+    plugins.withType<com.android.build.gradle.api.AndroidBasePlugin>() {
+        apply(plugin = "org.gradle.android.cache-fix")
+    }
+}
+```
+</details>
 
 <details>
 <summary>Groovy</summary>
@@ -93,22 +111,6 @@ plugins {
 subprojects {
     plugins.withType(com.android.build.gradle.api.AndroidBasePlugin) {
         project.apply plugin: "org.gradle.android.cache-fix"
-    }
-}
-```
-</details>
-<details open>
-<summary>Kotlin</summary>
-<br>
-
-```kotlin
-plugins {
-    id("org.gradle.android.cache-fix") version "2.7.0" apply false
-}
-
-subprojects {
-    plugins.withType<com.android.build.gradle.api.AndroidBasePlugin>() {
-        apply(plugin = "org.gradle.android.cache-fix")
     }
 }
 ```
@@ -156,16 +158,6 @@ do so in a manageable way, it imposes some restrictions:
 processor argument.  If an explicit annotation processor argument is provided, an exception will be thrown, instructing
 the user to configure it via the extension:
 
-<details>
-<summary>Groovy</summary>
-<br>
-
-```groovy
-room {
-    schemaLocationDir = file("roomSchemas")
-}
-```
-</details>
 <details open>
 <summary>Kotlin</summary>
 <br>
@@ -173,6 +165,17 @@ room {
 ```kotlin
 room {
     schemaLocationDir.set(file("roomSchemas"))
+}
+```
+</details>
+
+<details>
+<summary>Groovy</summary>
+<br>
+
+```groovy
+room {
+    schemaLocationDir = file("roomSchemas")
 }
 ```
 </details>
@@ -185,16 +188,6 @@ Since version 2.7.0, `RoomSchemaLocationWorkaround` supports Kotlin Symbol Proce
 processor with Ksp was causing cache misses. The workaround allows you to specify an output directory for Room schema
 exports. The schema export directory must be configured via the "room" project extension instead of the Ksp
 configuration:
-<details>
-<summary>Groovy</summary>
-<br>
-
-```groovy
-room {
-    schemaLocationDir = file("roomSchemas")
-}
-```
-</details>
 <details open>
 <summary>Kotlin</summary>
 <br>
@@ -205,6 +198,18 @@ room {
 }
 ```
 </details>
+
+<details>
+<summary>Groovy</summary>
+<br>
+
+```groovy
+room {
+    schemaLocationDir = file("roomSchemas")
+}
+```
+</details>
+
 
 Supported Ksp versions: 1.7.20-1.0.8+
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ If you discover an issue related to the Android Gradle Plugin, please file an is
 
 This plugin should be applied anywhere the `com.android.application` or `com.android.library` plugins are applied. We recommend adding the plugin to your project's [conventions plugin](https://docs.gradle.org/current/samples/sample_convention_plugins.html).
 
-<details open>
+<details>
 <summary>Groovy</summary>
 <br>
 
@@ -57,7 +57,7 @@ plugins {
 ```
 
 </details>
-<details>
+<details open>
 <summary>Kotlin</summary>
 <br>
 
@@ -81,7 +81,7 @@ plugins {
 If you are not using convention plugins and would like a quick way of testing the plugin you can alternatively place it in the root project's build.gradle (change '2.7.0' to the latest version of the cache fix plugin
 [here](https://plugins.gradle.org/plugin/org.gradle.android.cache-fix)). We discourage this approach because it uses [cross project configuration](https://docs.gradle.org/current/userguide/sharing_build_logic_between_subprojects.html#sec:convention_plugins_vs_cross_configuration).
 
-<details open>
+<details>
 <summary>Groovy</summary>
 <br>
 
@@ -97,7 +97,7 @@ subprojects {
 }
 ```
 </details>
-<details>
+<details open>
 <summary>Kotlin</summary>
 <br>
 
@@ -156,7 +156,7 @@ do so in a manageable way, it imposes some restrictions:
 processor argument.  If an explicit annotation processor argument is provided, an exception will be thrown, instructing
 the user to configure it via the extension:
 
-<details open>
+<details>
 <summary>Groovy</summary>
 <br>
 
@@ -166,7 +166,7 @@ room {
 }
 ```
 </details>
-<details>
+<details open>
 <summary>Kotlin</summary>
 <br>
 
@@ -185,7 +185,7 @@ Since version 2.7.0, `RoomSchemaLocationWorkaround` supports Kotlin Symbol Proce
 processor with Ksp was causing cache misses. The workaround allows you to specify an output directory for Room schema
 exports. The schema export directory must be configured via the "room" project extension instead of the Ksp
 configuration:
-<details open>
+<details>
 <summary>Groovy</summary>
 <br>
 
@@ -195,7 +195,7 @@ room {
 }
 ```
 </details>
-<details>
+<details open>
 <summary>Kotlin</summary>
 <br>
 


### PR DESCRIPTION
After official announcement:
https://blog.gradle.org/kotlin-dsl-is-now-the-default-for-new-gradle-builds

enabling by default Kotlin DSL

closes #462 