### PR TITLE
Toolchains are auto-provisioned via the foojay plugin

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -1,0 +1,5 @@
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(11)
+    }
+}

--- a/buildSrc/settings.gradle
+++ b/buildSrc/settings.gradle
@@ -1,0 +1,3 @@
+plugins {
+    id 'org.gradle.toolchains.foojay-resolver-convention'
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,6 +1,7 @@
 plugins {
     id 'com.gradle.enterprise' version '3.13'
     id 'com.gradle.common-custom-user-data-gradle-plugin' version '1.10'
+    id 'org.gradle.toolchains.foojay-resolver-convention' version '0.4.0'
 }
 
 def isCI = System.getenv('GITHUB_ACTIONS') != null


### PR DESCRIPTION
Note that we also utilize toolchains in the SimpleAndroidApp. Enabling auto-provisioning unconditionally in the project under test causes issues with the [Gradle 7.0.2 test cases](https://ge.solutions-team.gradle.com/s/vcnnowpemgbts/tests/overview?outcome=failed). I'm exploring this separately.