### PR TITLE
fix incorrect gav logic in the migration

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -82,7 +82,7 @@ gradlePlugin {
 // in the TestKit plugin classpath.
 val localRepo = file("$buildDir/local-repo")
 
-val isProdPortal = System.getProperty("gradle.portal.url") != null
+val isProdPortal = System.getProperty("gradle.portal.url") == null
 // The legacy groupId gradle.plugin.* is only allowed when the plugin
 // has already been published
 val pluginGroupId = if (isCI && isProdPortal) "gradle.plugin.org.gradle.android" else project.group


### PR DESCRIPTION
During the kts migration, I wrongly changed:
```
def isProdPortal = !System.getProperty('gradle.portal.url')
```
by 
```
val isProdPortal = System.getProperty("gradle.portal.url") != null
```

This is causing a change in the group value when publishing the plugin in the release workflow. This pr applies the same logic 