### PR TITLE
Add workflow to submit GitHub dependency graph

### DIFF
--- a/.github/workflows/submit-github-dependency-graph.yml
+++ b/.github/workflows/submit-github-dependency-graph.yml
@@ -1,0 +1,24 @@
+name: Submit GitHub Dependency Graph
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+  
+permissions: write-all
+
+jobs:
+  generate-and-submit-graph:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-java@v3
+      with:
+        distribution: temurin
+        java-version: 11
+    - name: Setup Gradle
+      uses: gradle/gradle-build-action@v2    
+    - name: Generate dependency graph
+      uses: gradle/gradle-build-action/actions/dependency-graph-generate@v2
+    - name: Submit dependency graph
+      uses: gradle/gradle-build-action/actions/dependency-graph-submit@v2


### PR DESCRIPTION
This workflow will generate a dependency snapshot for the repository and upload it to the GitHub Dependency Submission API. It relies on experimental support in https://github.com/gradle/gradle-build-action.