### PR TITLE
Use latest versions of AGP for main build

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,8 +27,8 @@ repositories {
 
 dependencies {
     val versions = mapOf(
-        "agp" to "8.1.0-rc01",
-        "sdkBuildTools" to "31.1.0-rc01",
+        "agp" to "8.0.2",
+        "sdkBuildTools" to "31.0.2",
         "spock" to "2.3-groovy-3.0",
     )
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,8 +27,8 @@ repositories {
 
 dependencies {
     val versions = mapOf(
-        "agp" to "7.3.1",
-        "sdkBuildTools" to "30.0.4",
+        "agp" to "8.1.0-rc01",
+        "sdkBuildTools" to "31.1.0-rc01",
         "spock" to "2.3-groovy-3.0",
     )
 


### PR DESCRIPTION
It's not clear why we are using older versions of these libraries in `compileOnly` and `testImplementation` configurations. Newer versions should address some of the current security vulnerabilities.