### PR TITLE
Drop support for Kotlin 1.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Some Android plugin versions have issues with Gradle's build cache feature. When
 
 * Supported Gradle versions: 7.0+
 * Supported Android Gradle Plugin versions: 7.0.4, 7.1.3, 7.2.2, 7.3.1, 7.4.2, 8.0.2, 8.1.0-rc01 and 8.2.0-alpha11
-* Supported Kotlin versions: 1.6.0+
+* Supported Kotlin versions: 1.7.0+
 
 We only test against the latest patch versions of each minor version of Android Gradle Plugin.  This means that although it may work perfectly well with an older patch version (say 7.0.1), we do not test against these older patch versions, so the latest patch version is the only version from that minor release that we technically support.
 

--- a/src/test/groovy/org/gradle/android/RoomSchemaLocationKspWorkaroundTest.groovy
+++ b/src/test/groovy/org/gradle/android/RoomSchemaLocationKspWorkaroundTest.groovy
@@ -15,9 +15,6 @@ class RoomSchemaLocationKspWorkaroundTest extends RoomWorkaroundAbstractTest {
     def "schemas are generated with Ksp into task-specific directory and are cacheable (Android #androidVersion) (Kotlin #kotlinVersion)"() {
         def kotlinVersionNumber = VersionNumber.parse(kotlinVersion)
 
-        // The Room workaround for KSP does not support Kotlin version 1.6.x or lower
-        Assume.assumeTrue(kotlinVersionNumber >= VersionNumber.parse("1.7.0"))
-
         // AGP 8.2.0-alpha10 and higher require Kotlin 1.8.0 or higher
         if (androidVersion >= VersionNumber.parse("8.2.0-alpha10")) {
             Assume.assumeTrue(kotlinVersionNumber >= VersionNumber.parse("1.8.0"))
@@ -90,9 +87,6 @@ class RoomSchemaLocationKspWorkaroundTest extends RoomWorkaroundAbstractTest {
     @Unroll
     def "schemas are correctly generated with Ksp when only one variant is built incrementally (Android #androidVersion) (Kotlin #kotlinVersion)"() {
         def kotlinVersionNumber = VersionNumber.parse(kotlinVersion)
-
-        // The Room workaround for KSP does not support Kotlin version 1.6.x or lower
-        Assume.assumeTrue(kotlinVersionNumber >= VersionNumber.parse("1.7.0"))
 
         // AGP 8.2.0-alpha10 and higher require Kotlin 1.8.0 or higher
         if (androidVersion >= VersionNumber.parse("8.2.0-alpha10")) {

--- a/src/test/groovy/org/gradle/android/TestVersions.groovy
+++ b/src/test/groovy/org/gradle/android/TestVersions.groovy
@@ -41,7 +41,7 @@ class TestVersions {
     }
 
     // This map represents the Kotlin supported versions associated with Ksp supported versions
-    static Map<String, String> supportedKotlinVersions = ["1.6.21": "", "1.7.22": "1.7.22-1.0.8", "1.8.22": "1.8.22-1.0.11", "1.9.0": "1.9.0-1.0.11"]
+    static Map<String, String> supportedKotlinVersions = ["1.7.22": "1.7.22-1.0.8", "1.8.22": "1.8.22-1.0.11", "1.9.0": "1.9.0-1.0.11"]
 
     static VersionNumber latestSupportedKotlinVersion() {
         return VersionNumber.parse(supportedKotlinVersions.keySet().last().toString())


### PR DESCRIPTION
This will fix tests timing out due to taking a very long time.
Most Kotlin users are up-to-date on the latest versions.
