### PR TITLE
Enable all warnings as errors for buildscript compilation

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,5 +4,6 @@ org.gradle.parallel=true
 org.gradle.caching=true
 org.gradle.configuration-cache=true
 org.gradle.jvmargs=-Duser.language=en -Duser.country=US -Dfile.encoding=UTF-8
+org.gradle.kotlin.dsl.allWarningsAsErrors=true
 
 isPTSEnabled=false

--- a/release/changes.md
+++ b/release/changes.md
@@ -1,0 +1,2 @@
+- [NEW] Drop support for Kotlin 1.6.X
+- [NEW] Run tests against AGP 8.2.0-alpha11


### PR DESCRIPTION
Fail on script compilation warnings

See Gradle 8.2 release notes: https://docs.gradle.org/8.2/release-notes.html
