### PR TITLE
Removing support for PackageForUnitTest workaround in 8.3

### DIFF
--- a/src/main/groovy/org/gradle/android/workarounds/PackageForUnitTestWorkaround.groovy
+++ b/src/main/groovy/org/gradle/android/workarounds/PackageForUnitTestWorkaround.groovy
@@ -6,7 +6,7 @@ import org.gradle.android.AndroidIssue
 import org.gradle.api.Project
 import org.gradle.api.Task
 
-@AndroidIssue(introducedIn = "3.5.0-alpha05", link = "https://issuetracker.google.com/issues/292114808")
+@AndroidIssue(introducedIn = "3.5.0-alpha05", fixedIn = "8.3.0-alpha01", link = "https://issuetracker.google.com/issues/292114808")
 @CompileStatic
 class PackageForUnitTestWorkaround implements Workaround {
     private static final String CACHING_ENABLED_PROPERTY = "org.gradle.android.cache-fix.PackageForUnitTest.caching.enabled"

--- a/src/test/groovy/org/gradle/android/WorkaroundTest.groovy
+++ b/src/test/groovy/org/gradle/android/WorkaroundTest.groovy
@@ -12,7 +12,7 @@ class WorkaroundTest extends Specification {
         workarounds.collect { it.class.simpleName.replaceAll(/Workaround/, "") }.sort() == expectedWorkarounds.sort()
         where:
         androidVersion  | expectedWorkarounds
-        "8.3.0-alpha01" | ['MergeSourceSetFolders', 'RoomSchemaLocation', 'ZipMergingTask', 'JdkImage', 'PackageForUnitTest']
+        "8.3.0-alpha01" | ['MergeSourceSetFolders', 'RoomSchemaLocation', 'ZipMergingTask', 'JdkImage']
         "8.2.0-beta01"  | ['MergeSourceSetFolders', 'RoomSchemaLocation', 'ZipMergingTask', 'JdkImage', 'PackageForUnitTest']
         "8.1.1"         | ['MergeSourceSetFolders', 'RoomSchemaLocation', 'ZipMergingTask', 'JdkImage', 'PackageForUnitTest']
         "8.0.2"         | ['MergeSourceSetFolders', 'RoomSchemaLocation', 'ZipMergingTask', 'JdkImage', 'PackageForUnitTest']


### PR DESCRIPTION
AGP 8.3 has disabled caching for PackageForUnitTest tasks. Issue has been marked as fixed:
https://issuetracker.google.com/issues/292114808
This PR drops support for PackageForUnitTest workaround in AGP 8.3.

**Tests**
AGP 8.1.1: Build Cache Result --> Miss (local), Store (local) --> https://ge.solutions-team.gradle.com/s/acdqg2r7ntsww/timeline?details=p4gvuy5bywso4&type=com.android.build.gradle.internal.tasks.PackageForUnitTest

AGP 8.3.0-alpha01:  Not cacheable --> Simple merging task. -->  https://ge.solutions-team.gradle.com/s/dqo7hoygh73hg/timeline?details=p4gvuy5bywso4&type=com.android.build.gradle.internal.tasks.PackageForUnitTest