### PR TITLE
Add FixedIn to ZipMergingTask

### DIFF
--- a/src/main/groovy/org/gradle/android/workarounds/ZipMergingTaskWorkaround.groovy
+++ b/src/main/groovy/org/gradle/android/workarounds/ZipMergingTaskWorkaround.groovy
@@ -10,7 +10,7 @@ import org.gradle.api.Task
  * Disables caching of ZipMergingTask which is mostly disk bound and
  * unlikely to provide positive performance benefits.
  */
-@AndroidIssue(introducedIn = "3.5.0", fixedIn = [], link="https://issuetracker.google.com/issues/200002454")
+@AndroidIssue(introducedIn = "3.5.0", fixedIn = "8.1.0-alpha10", link="https://issuetracker.google.com/issues/200002454")
 @CompileStatic
 class ZipMergingTaskWorkaround implements Workaround {
 

--- a/src/test/groovy/org/gradle/android/WorkaroundTest.groovy
+++ b/src/test/groovy/org/gradle/android/WorkaroundTest.groovy
@@ -12,9 +12,9 @@ class WorkaroundTest extends Specification {
         workarounds.collect { it.class.simpleName.replaceAll(/Workaround/, "") }.sort() == expectedWorkarounds.sort()
         where:
         androidVersion  | expectedWorkarounds
-        "8.3.0-alpha11" | ['MergeSourceSetFolders', 'ZipMergingTask', 'JdkImage']
-        "8.2.0-rc02"    | ['MergeSourceSetFolders', 'ZipMergingTask', 'JdkImage', 'PackageForUnitTest']
-        "8.1.2"         | ['MergeSourceSetFolders', 'ZipMergingTask', 'JdkImage', 'PackageForUnitTest']
+        "8.3.0-alpha11" | ['MergeSourceSetFolders', 'JdkImage']
+        "8.2.0-rc02"    | ['MergeSourceSetFolders', 'JdkImage', 'PackageForUnitTest']
+        "8.1.2"         | ['MergeSourceSetFolders', 'JdkImage', 'PackageForUnitTest']
         "8.0.2"         | ['MergeSourceSetFolders', 'ZipMergingTask', 'JdkImage', 'PackageForUnitTest']
         "7.4.2"         | ['MergeSourceSetFolders', 'ZipMergingTask', 'JdkImage', 'PackageForUnitTest']
         "7.3.1"         | ['MergeSourceSetFolders', 'ZipMergingTask', 'JdkImage', 'PackageForUnitTest']


### PR DESCRIPTION
This was fixed in AGP 8.1.0-alpha10

https://issuetracker.google.com/issues/272740536

Fixes #606
