### PR TITLE
Removing patch_api_version step

### DIFF
--- a/.github/workflows/build-verification.yml
+++ b/.github/workflows/build-verification.yml
@@ -67,13 +67,10 @@ jobs:
         versions: ${{ fromJson(needs.generate_versions.outputs.matrix) }}
     steps:
       - uses: actions/checkout@v4
-      # Patch issue in platform-tools 31.0.3 where platform-tools/api/api-versions.xml is missing (see https://issuetracker.google.com/issues/195445762)
-      - name: Patch api-versions
-        run: sudo test -f $ANDROID_HOME/platform-tools/api/api-versions.xml || (sudo mkdir $ANDROID_HOME/platform-tools/api && sudo cp .github/api-versions.xml $ANDROID_HOME/platform-tools/api/api-versions.xml)
       - name: List Android Packages
-        run: sudo $ANDROID_HOME/tools/bin/sdkmanager --list | sed -n '/Available Packages/q;p'
+        run: sudo ${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager --list | sed -n '/Available Packages/q;p'
       - name: Accept license 34.0.0
-        run: echo "y" | sudo $ANDROID_HOME/tools/bin/sdkmanager "build-tools;34.0.0"
+        run: echo "y" | sudo ${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager "build-tools;34.0.0"
       - name: Setup ZULU_JDK
         uses: actions/setup-java@v4
         with:


### PR DESCRIPTION
The Android SDK Platform-Tools got removed completely from the image ubuntu22/20240107.1 causing jobs failing at the step `Patch api-version` https://github.com/gradle/android-cache-fix-gradle-plugin/actions/runs/7493334606/job/20399411965

Because it's removed this PR removes the patch api step because is not required also it removes the file required for the workaround. 

Additionally, this pr updates the sdk manager references in the steps `List Android Packages` and `Accept license 34.0.0`([ref](https://github.com/actions/runner-images/issues/9146)):
`$ANDROID_HOME/tools/bin/sdkmanager` to `${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager`
