### PR TITLE
Use `gradle/actions/setup-gradle` and `gradle/actions/dependency-submission`

### DIFF
--- a/.github/workflows/build-verification.yml
+++ b/.github/workflows/build-verification.yml
@@ -29,7 +29,7 @@ jobs:
           java-version: 11
           distribution: 'temurin'
       - name: Set up Gradle
-        uses: gradle/gradle-build-action@v3
+        uses: gradle/actions/setup-gradle@v3
       - name: Run sanityCheck
         run: ./gradlew sanityCheck -Porg.gradle.java.installations.auto-download=false
         env:
@@ -45,7 +45,7 @@ jobs:
           java-version: 11
           distribution: 'temurin'
       - name: Set up Gradle
-        uses: gradle/gradle-build-action@v3
+        uses: gradle/actions/setup-gradle@v3
       - name: Run unit tests
         run: >-
             ./gradlew test
@@ -98,7 +98,7 @@ jobs:
           java-version: 17
           distribution: 'temurin'
       - name: Set up Gradle
-        uses: gradle/gradle-build-action@v3
+        uses: gradle/actions/setup-gradle@v3
       - name: Run integration tests
         run: >-
             ./gradlew testAndroid${{ matrix.versions }}

--- a/.github/workflows/submit-github-dependency-graph.yml
+++ b/.github/workflows/submit-github-dependency-graph.yml
@@ -17,7 +17,7 @@ jobs:
         distribution: temurin
         java-version: 11
     - name: Setup Gradle
-      uses: gradle/gradle-build-action@v3
+      uses: gradle/actions/setup-gradle@v3
       with:
         dependency-graph: generate-and-submit
     - name: Run 'publish' to generate dependency graph

--- a/.github/workflows/submit-github-dependency-graph.yml
+++ b/.github/workflows/submit-github-dependency-graph.yml
@@ -5,7 +5,8 @@ on:
     branches:
       - main
   
-permissions: write-all
+permissions:
+  contents: write
 
 jobs:
   generate-and-submit:
@@ -16,11 +17,8 @@ jobs:
       with:
         distribution: temurin
         java-version: 11
-    - name: Setup Gradle
-      uses: gradle/actions/setup-gradle@v3
-      with:
-        dependency-graph: generate-and-submit
-    - name: Run 'publish' to generate dependency graph
-      run: ./gradlew publish -Porg.gradle.java.installations.auto-download=false
+    - name: Submit dependency graph
+      uses: gradle/actions/dependency-submission@v3
       env:
+        DEPENDENCY_GRAPH_EXCLUDE_CONFIGURATIONS: '.*[Tt]est(Compile|Runtime)Classpath'
         GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GE_SOLUTIONS_ACCESS_TOKEN }}

--- a/.github/workflows/wrapper-upgrade-execution.yml
+++ b/.github/workflows/wrapper-upgrade-execution.yml
@@ -31,7 +31,7 @@ jobs:
           java-version: '11'
           distribution: 'temurin'
       - name: Set up Gradle
-        uses: gradle/gradle-build-action@v3
+        uses: gradle/actions/setup-gradle@v3
       - name: Upgrade Wrappers
         run: ./gradlew clean upgradeGradleWrapperAll --continue -Porg.gradle.java.installations.auto-download=false
         env:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,6 +3,19 @@ import com.gradle.enterprise.gradleplugin.testselection.PredictiveTestSelectionP
 import com.gradle.enterprise.gradleplugin.testselection.PredictiveTestSelectionProfile.STANDARD
 import groovy.json.JsonSlurper
 
+// Upgrade transitive dependencies in plugin classpath
+buildscript {
+    repositories {
+        gradlePluginPortal()
+    }
+    dependencies {
+        constraints {
+            // Dependency of 'com.github.breadmoirai.github-release:2.5.2'
+            classpath("com.squareup.okio:okio:3.4.0") // CVE-2023-3635
+        }
+    }
+}
+
 plugins {
     id("groovy")
     id("java-gradle-plugin")


### PR DESCRIPTION
- Replaces use of `gradle/gradle-build-action` with `gradle/actions/setup-gradle`.
- Replaces custom dependency graph workflow with simpler one using `gradle/actions/dependency-submission`.
- Fixes a reported vulnerability by upgrading transitive dependency in plugin classpath.