### PR TITLE
Bump supported AGP version from 8.4.0-alpha08 to 8.4.0-alpha09

### DIFF
--- a/src/main/resources/versions.json
+++ b/src/main/resources/versions.json
@@ -1,6 +1,6 @@
 {
     "supportedVersions": {
-        "8.4.0-alpha08": [
+        "8.4.0-alpha09": [
             "8.6"
         ],
         "8.3.0-rc01": [

--- a/src/test/groovy/org/gradle/android/WorkaroundTest.groovy
+++ b/src/test/groovy/org/gradle/android/WorkaroundTest.groovy
@@ -12,7 +12,7 @@ class WorkaroundTest extends Specification {
         workarounds.collect { it.class.simpleName.replaceAll(/Workaround/, "") }.sort() == expectedWorkarounds.sort()
         where:
         androidVersion  | expectedWorkarounds
-        "8.4.0-alpha08" | ['JdkImage']
+        "8.4.0-alpha09" | ['JdkImage']
         "8.3.0-rc01"    | ['MergeSourceSetFolders', 'JdkImage']
         "8.2.2"         | ['MergeSourceSetFolders', 'JdkImage', 'PackageForUnitTest']
         "8.1.4"         | ['MergeSourceSetFolders', 'JdkImage', 'PackageForUnitTest']

--- a/src/test/resources/expectedOutcomes/8.4.0-alpha09_outcomes.json
+++ b/src/test/resources/expectedOutcomes/8.4.0-alpha09_outcomes.json
@@ -98,6 +98,8 @@
     ":app:writeDebugSigningConfigVersions"               :  "SUCCESS",
     ":app:writeReleaseAppMetadata"                       :  "SUCCESS",
     ":app:writeReleaseSigningConfigVersions"             :  "SUCCESS",
+    ":app:mergeDebugStartupProfile"                      :  "SUCCESS",
+    ":app:mergeReleaseStartupProfile"                    :  "SUCCESS",
     ":library:assemble"                                  :  "SUCCESS",
     ":library:assembleDebug"                             :  "SUCCESS",
     ":library:assembleRelease"                           :  "SUCCESS",


### PR DESCRIPTION
This PR bump supported AGP version from `8.4.0-alpha08` to `8.4.0-alpha09`.