### PR TITLE
Update Link to Room Gradle Plugin Release

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ Not fixed by the Android Cache Fix plugin since it has no workaround but is fixe
 
 ### Room
 The Room annotation processor causes cache misses: https://issuetracker.google.com/issues/132245929.
-To work around this issue, please apply the [Room Gradle Plugin](https://developer.android.com/jetpack/androidx/releases/room#2.6.0-alpha02).
+To work around this issue, please apply the [Room Gradle Plugin](https://developer.android.com/jetpack/androidx/releases/room#2.6.0).
 
 
 ## Implementation Notes


### PR DESCRIPTION
Since 2.6.0-alpha02, the Room Gradle Plugin is available. But now that Room 2.6.0 (and later) are released, it would be more appropriate to point users to the 2.6.0 major release containing this plugin.