### PR TITLE
Fix android debug keystore creation

### DIFF
--- a/.github/workflows/build-verification.yml
+++ b/.github/workflows/build-verification.yml
@@ -72,6 +72,10 @@ jobs:
         run: sudo ${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager --list | sed -n '/Available Packages/q;p'
       - name: Accept license 34.0.0
         run: echo "y" | sudo ${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager "build-tools;34.0.0"
+      - name: Create Android keystore folder
+        run: |
+          mkdir -p /home/runner/.config/.android
+          keytool -genkey -v -keystore /tmp/debug.keystore -storepass android -alias androiddebugkeynondefault -keypass android -keyalg RSA -keysize 2048 -validity 10000 -dname "C=US, O=Android, CN=Android Debug"
       - name: Setup ZULU_JDK
         uses: actions/setup-java@v4
         with:

--- a/.github/workflows/build-verification.yml
+++ b/.github/workflows/build-verification.yml
@@ -112,6 +112,8 @@ jobs:
             -x signPluginMavenPublication
             -x signAndroidCacheFixPluginPluginMarkerMavenPublication
             -Porg.gradle.java.installations.auto-download=false
-            -Dpts.mode=$PTS_MODE
+            --no-build-cache
+            -Dpts.enabled=false
+#            -Dpts.mode=$PTS_MODE
         env:
           PTS_MODE: "${{ github.ref_name == 'main' && 'REMAINING_TESTS' || 'RELEVANT_TESTS' }}"

--- a/src/test/groovy/org/gradle/android/SimpleAndroidApp.groovy
+++ b/src/test/groovy/org/gradle/android/SimpleAndroidApp.groovy
@@ -197,6 +197,14 @@ class SimpleAndroidApp {
                         checkReleaseBuilds false
                     }
                 }
+                signingConfigs {
+                    getByName("debug") {
+                        storeFile = file("/tmp/debug.keystore")
+                        storePassword = "android"
+                        keyAlias = "androiddebugkeynondefault"
+                        keyPassword = "android"
+                    }
+                }
             }
 
             ${toolchainConfigurationIfEnabled}


### PR DESCRIPTION
Tests with AGP 8.1 and above fails with [this error](https://ge.solutions-team.gradle.com/s/dsw4fxsmhzluc/tests/task/:testAndroid8_1_4/details/org.gradle.android.JdkImageWorkaroundTest/jdkImage%20is%20normalized%20when%20using%20the%20same%20JDK%20version?focused-exception-line=1-128&top-execution=2)

Creating a keystore in a writable location fixes it