### PR TITLE
Removing manual installation build tools 34.0.0

### DIFF
--- a/.github/workflows/build-verification.yml
+++ b/.github/workflows/build-verification.yml
@@ -68,10 +68,6 @@ jobs:
         versions: ${{ fromJson(needs.generate_versions.outputs.matrix) }}
     steps:
       - uses: actions/checkout@v4
-      - name: List Android Packages
-        run: sudo ${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager --list | sed -n '/Available Packages/q;p'
-      - name: Accept license 34.0.0
-        run: echo "y" | sudo ${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager "build-tools;34.0.0"
       - name: Setup ZULU_JDK
         uses: actions/setup-java@v4
         with:


### PR DESCRIPTION
Recent jobs on CI builds from AGP versions were failing with:
```
java.io.IOException: Unable to create debug keystore in /home/runner/.config/.android because it is not writable.
```
There is an initial workaround to fix this problem in PR #1720. The proposed solution is valid, but while trying to understand the reason for the failure, we observed that it is caused by an attempt to write to the Android folder during the build. This occurs in a folder created by a different user (root). The original folder is created when manually installing the SDK build tool version 34.0.0(during the gha setup):
```
      - name: List Android Packages
        run: sudo ${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager --list | sed -n '/Available Packages/q;p'
      - name: Accept license 34.0.0
        run: echo "y" | sudo ${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager "build-tools;34.0.0"
```
Given this situation, we need to understand what caused this change in the GHA infrastructure: The ubuntu-latest workflows have started [rolling out](https://github.com/actions/runner-images/issues/10636) the ubuntu-24.04 image since December 5th (scheduled to be completed by January 17th). One of the changes in the new version is the use of SDK build tools version 34.0.0.

This PR removes the manual installation of the SDK tools (performed as root), resolving the folder permission issue caused by the user mismatch.