### PR TITLE
Update JdkImageWorkaround.groovy to reflect that the issue was fixed in AGP 7.4.0-alpha07

### DIFF
--- a/src/main/groovy/org/gradle/android/workarounds/JdkImageWorkaround.groovy
+++ b/src/main/groovy/org/gradle/android/workarounds/JdkImageWorkaround.groovy
@@ -35,7 +35,7 @@ import java.util.stream.Stream
  * than Java 9.  This normalizes out minor inconsequential differences between JDKs used to generate the
  * custom runtime and improve cache hits between environments.
  */
-@AndroidIssue(introducedIn = "7.1.0", link = "https://issuetracker.google.com/u/1/issues/234820480")
+@AndroidIssue(introducedIn = "7.1.0", fixedIn = "7.4.0-alpha07", link = "https://issuetracker.google.com/u/1/issues/234820480")
 class JdkImageWorkaround implements Workaround {
     static final String WORKAROUND_ENABLED_PROPERTY = "org.gradle.android.cache-fix.JdkImageWorkaround.enabled"
 


### PR DESCRIPTION
A minor update updating the @AndroidIssue annotation to clarify that the issue is no longer present in newer versions of AGP.