### PR TITLE
Adjust Renovate config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -6,7 +6,7 @@
   ],
   // See https://docs.renovatebot.com/modules/manager/regex/
   // Dependabot is used for all other updates.
-  "enabledManagers": ["regex"],
+  "enabledManagers": ["custom.regex"],
   "customManagers": [
     {
       // Matches AGP versions annotated with a "renovate: AGP version" comment

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -3,6 +3,7 @@
   "extends": [
     "config:recommended",
     "github>gradle/renovate-agent//presets/dv.json5",
+    ":disableDependencyDashboard",
   ],
   // See https://docs.renovatebot.com/modules/manager/regex/
   // Dependabot is used for all other updates.

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -40,6 +40,12 @@
       "enabled": false,
     },
     {
+      // In gradle.properties, allow unstable versions
+      "matchDepNames": ["com.android.tools.build:gradle"],
+      "matchFileNames": ["gradle\\.properties"],
+      "ignoreUnstable": false,
+    },
+    {
       // Group changes about AGP versions
       "matchFileNames": [
         "src/main/resources/versions\\.json5",

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -39,9 +39,12 @@
       "enabled": false,
     },
     {
-      // Group changes to versions.json5
-      "matchFileNames": ["src/main/resources/versions\\.json5"],
-      "groupName": "supportedVersions",
+      // Group changes about AGP versions
+      "matchFileNames": [
+        "src/main/resources/versions\\.json5",
+        "gradle\\.properties",
+      ],
+      "groupName": "AGP versions",
     },
   ],
 }


### PR DESCRIPTION
- Always allow pre-release in `latestKnownAgpVersion` property
    
    Default behavior would be to only allow it while it's already unstable (currently the case).

- Disable dependency dashboard (#1746)

 - Migrate deprecated setting
    
    Assuming this is the main change proposed by Renovate in #1749. It's a noisy diff there due to syntax changes.

- Group all AGP version changes in single PR

    This should prevent the check failure that's currently affecting #1747 and #1748. Making them a single PR should fix that error.

These changes were tested on a fork. An example PR is gabrielfeo/android-cache-fix-gradle-plugin#12). A [help][1] build on that branch confirms that the new PR should pass the current error.

[1]: https://ge.solutions-team.gradle.com/s/hvjxrb36dfoja