### PR TITLE
Fix generate_versions job

### DIFF
--- a/.github/workflows/build-verification.yml
+++ b/.github/workflows/build-verification.yml
@@ -13,10 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - id: setup-matrix
-        shell: bash
-        run: |
-          set -euo pipefail
-          echo "matrix=$(jq -cM '.supportedVersions | keys' src/main/resources/versions.json | sed -e 's/\./_/g' -e 's/-/_/g')" >> $GITHUB_OUTPUT
+        run: echo "matrix=$(jq -cM '.supportedVersions | keys' src/main/resources/versions.json | sed -e 's/\./_/g' -e 's/-/_/g')" >> $GITHUB_OUTPUT
       - name: debug
         run: echo "matrix=${{ steps.setup-matrix.outputs.matrix }}"
     outputs:

--- a/.github/workflows/build-verification.yml
+++ b/.github/workflows/build-verification.yml
@@ -13,7 +13,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - id: setup-matrix
-        run: echo "matrix=$(jq -cM '.supportedVersions | keys' src/main/resources/versions.json | sed -e 's/\./_/g' -e 's/-/_/g')" >> $GITHUB_OUTPUT
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "matrix=$(jq -cM '.supportedVersions | keys' src/main/resources/versions.json | sed -e 's/\./_/g' -e 's/-/_/g')" >> $GITHUB_OUTPUT
       - name: debug
         run: echo "matrix=${{ steps.setup-matrix.outputs.matrix }}"
     outputs:

--- a/.github/workflows/build-verification.yml
+++ b/.github/workflows/build-verification.yml
@@ -13,9 +13,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - id: setup-matrix
-        run: echo "matrix=$(jq -cM '.supportedVersions | keys' src/main/resources/versions.json | sed -e 's/\./_/g' -e 's/-/_/g')" >> $GITHUB_OUTPUT
-      - name: debug
-        run: echo "matrix=${{ steps.setup-matrix.outputs.matrix }}"
+        shell: bash
+        run: |
+          set -euo pipefail
+          json_to_matrix() {
+            jq -cM '.supportedVersions | keys' src/main/resources/versions.json | sed -e 's/\./_/g' -e 's/-/_/g'
+          }
+          json_to_matrix
+          echo "matrix=$(json_to_matrix)" >> $GITHUB_OUTPUT
     outputs:
       matrix: ${{ steps.setup-matrix.outputs.matrix }}
 

--- a/.github/workflows/build-verification.yml
+++ b/.github/workflows/build-verification.yml
@@ -17,7 +17,8 @@ jobs:
         run: |
           set -euo pipefail
           json_to_matrix() {
-            jq -cM '.supportedVersions | keys' src/main/resources/versions.json | sed -e 's/\./_/g' -e 's/-/_/g'
+            json_without_comments="$(sed -E 's|\s//.*||' src/main/resources/versions.json5)"
+            echo "$json_without_comments" | jq -cM '.supportedVersions | keys' | sed -e 's/\./_/g' -e 's/-/_/g'
           }
           json_to_matrix
           echo "matrix=$(json_to_matrix)" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Since #1742, the `generate_versions` CI job [succeeds even though it can't parse the JSON file][1]. Parsing fails because `jq` [doesn't support JSON5][2]. The job succeeds silently despite this failure because it's ran inside [command substitution][3]. This currently results in #1751 not running proper tests.

Fix the `generate_versions` CI job to correctly parse the JSON5 file by stripping comment lines before passing its content to `jq`. Also ensure the job will fail if the step fails by running it once outside command substitution and ensuring `pipefail` is on. This replaces the "debug" step.

[1]: https://github.com/gradle/android-cache-fix-gradle-plugin/actions/runs/12717112831
[2]: https://github.com/jqlang/jq/issues/1571
[3]: https://www.gnu.org/software/bash/manual/html_node/Command-Substitution.html