### PR TITLE
Update Renovate config to avoid JSON5

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -12,22 +12,16 @@
     {
       // Matches AGP versions in versions.json
       customType: "regex",
-      fileMatch: ["src/main/resources/versions\\.json"],
-      "matchStringsStrategy": "recursive",
-      "matchStrings": [
-        // Matches versions followed by a list, e.g. "8.9.0": [. See https://docs.renovatebot.com/configuration-options/#recursive
-        "\\s+?\"(?<currentValue>\\S+?)\": \\[",
+      fileMatch: [
+        "src/main/resources/versions\\.json",
+        "gradle\\.properties",
       ],
-      "datasourceTemplate": "maven",
-      "versioningTemplate": "maven",
-      "depNameTemplate": "com.android.tools.build:gradle",
-      "registryUrlTemplate": "https://dl.google.com/dl/android/maven2/",
-    },
-    {
-      // Matches AGP versions annotated with a "renovate: AGP version" comment
-      customType: "regex",
-      fileMatch: ["gradle\\.properties"],
-      matchStrings: ["# renovate: AGP version\\s+?\\S+?=(?<currentValue>\\S+?)(?:\\s|$)"],
+      "matchStrings": [
+        // In versions.json, matches keys with a list value, e.g. "8.9.0": [
+        "\\s+?\"(?<currentValue>\\S+?)\": \\[",
+        // In gradle.properties, matches a specific property's value
+        "org\\.gradle\\.android\\.latestKnownAgpVersion=(?<currentValue>\\S+?)(?:\\s|$)",
+      ],
       "datasourceTemplate": "maven",
       "versioningTemplate": "maven",
       "depNameTemplate": "com.android.tools.build:gradle",

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -10,18 +10,24 @@
   "enabledManagers": ["custom.regex"],
   "customManagers": [
     {
+      // Matches AGP versions in versions.json
+      customType: "regex",
+      fileMatch: ["src/main/resources/versions\\.json"],
+      "matchStringsStrategy": "recursive",
+      "matchStrings": [
+        // Matches versions followed by a list, e.g. "8.9.0": [. See https://docs.renovatebot.com/configuration-options/#recursive
+        "\\s+?\"(?<currentValue>\\S+?)\": \\[",
+      ],
+      "datasourceTemplate": "maven",
+      "versioningTemplate": "maven",
+      "depNameTemplate": "com.android.tools.build:gradle",
+      "registryUrlTemplate": "https://dl.google.com/dl/android/maven2/",
+    },
+    {
       // Matches AGP versions annotated with a "renovate: AGP version" comment
       customType: "regex",
-      fileMatch: [
-        "src/main/resources/versions\\.json5",
-        "gradle\\.properties",
-      ],
-      matchStrings: [
-        // For JSON: the first double-quoted string below the comment line, e.g. "1.0.0"
-        "\/\/ renovate: AGP version\\s+?\"(?<currentValue>\\S+?)\"",
-        // For properties: the value of the first property below the comment line, e.g. anyProperty=1.0.0
-        "# renovate: AGP version\\s+?\\S+?=(?<currentValue>\\S+?)(?:\\s|$)",
-      ],
+      fileMatch: ["gradle\\.properties"],
+      matchStrings: ["# renovate: AGP version\\s+?\\S+?=(?<currentValue>\\S+?)(?:\\s|$)"],
       "datasourceTemplate": "maven",
       "versioningTemplate": "maven",
       "depNameTemplate": "com.android.tools.build:gradle",
@@ -29,14 +35,14 @@
     },
   ],
   // Ensure patches to older minors are opened, even if a newer minor is available
-  // In versions.json5, means older minors will still be checked for a newer patch
+  // In versions.json, means older minors will still be checked for a newer patch
   "separateMinorPatch": true,
   "packageRules": [
     {
-      // In versions.json5, disable bumps of major/minor, which should be added as new properties
+      // In versions.json, disable bumps of major/minor, which should be added as new properties
       "matchDepNames": ["com.android.tools.build:gradle"],
       "matchUpdateTypes": ["major", "minor"],
-      "matchFileNames": ["src/main/resources/versions\\.json5"],
+      "matchFileNames": ["src/main/resources/versions\\.json"],
       "enabled": false,
     },
     {
@@ -48,7 +54,7 @@
     {
       // Group changes about AGP versions
       "matchFileNames": [
-        "src/main/resources/versions\\.json5",
+        "src/main/resources/versions\\.json",
         "gradle\\.properties",
       ],
       "groupName": "AGP versions",

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -10,7 +10,7 @@
   "enabledManagers": ["custom.regex"],
   "customManagers": [
     {
-      // Matches AGP versions in versions.json
+      // Matches AGP versions in files with custom patterns
       customType: "regex",
       fileMatch: [
         "src/main/resources/versions\\.json",

--- a/.github/workflows/build-verification.yml
+++ b/.github/workflows/build-verification.yml
@@ -17,8 +17,8 @@ jobs:
         run: |
           set -euo pipefail
           json_to_matrix() {
-            json_without_comments="$(sed -E 's|\s//.*||' src/main/resources/versions.json5)"
-            echo "$json_without_comments" | jq -cM '.supportedVersions | keys' | sed -e 's/\./_/g' -e 's/-/_/g'
+            file="src/main/resources/versions.json"
+            jq -cM '.supportedVersions | keys' "$file" | sed -e 's/\./_/g' -e 's/-/_/g'
           }
           json_to_matrix
           echo "matrix=$(json_to_matrix)" >> $GITHUB_OUTPUT

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,6 @@
 import com.gradle.develocity.agent.gradle.test.PredictiveTestSelectionProfile.FAST
 import com.gradle.develocity.agent.gradle.test.PredictiveTestSelectionProfile.STANDARD
 import groovy.json.JsonSlurper
-import groovy.json.JsonParserType
 
 // Upgrade transitive dependencies in plugin classpath
 buildscript {
@@ -266,8 +265,7 @@ fun releaseNotes(): Provider<String> {
 
 @Suppress("UNCHECKED_CAST")
 fun readSupportedVersions(): Map<String, Array<String>> {
-    val versionFile = providers.fileContents(layout.projectDirectory.file("src/main/resources/versions.json5"))
-    val slurper = JsonSlurper().setType(JsonParserType.LAX)
-    val json = slurper.parse(versionFile.asBytes.get()) as Map<String, Map<String, Array<String>>>
+    val versionFile = providers.fileContents(layout.projectDirectory.file("src/main/resources/versions.json"))
+    val json = JsonSlurper().parse(versionFile.asBytes.get()) as Map<String, Map<String, Array<String>>>
     return json.getValue("supportedVersions")
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,5 +6,4 @@ org.gradle.kotlin.dsl.allWarningsAsErrors=true
 
 systemProp.pts.enabled=true
 
-# renovate: AGP version
 org.gradle.android.latestKnownAgpVersion=8.9.0-alpha09

--- a/src/main/groovy/org/gradle/android/Versions.groovy
+++ b/src/main/groovy/org/gradle/android/Versions.groovy
@@ -5,7 +5,6 @@ import com.google.common.collect.ImmutableMultimap
 import com.google.common.collect.ImmutableSortedSet
 import com.google.common.collect.Multimap
 import groovy.json.JsonSlurper
-import groovy.json.JsonParserType
 import groovy.transform.CompileStatic
 import groovy.transform.TypeCheckingMode
 import org.gradle.util.GradleVersion
@@ -18,8 +17,7 @@ class Versions {
     static final VersionNumber CURRENT_ANDROID_VERSION
 
     static {
-        def slurper = new JsonSlurper().setType(JsonParserType.LAX)
-        def versions = slurper.parse(AndroidCacheFixPlugin.classLoader.getResource("versions.json5"))
+        def versions = new JsonSlurper().parse(AndroidCacheFixPlugin.classLoader.getResource("versions.json"))
 
         def builder = ImmutableMultimap.<VersionNumber, GradleVersion>builder()
         versions.supportedVersions.each { String androidVersion, List<String> gradleVersions ->

--- a/src/main/resources/versions.json
+++ b/src/main/resources/versions.json
@@ -1,65 +1,50 @@
 {
     "supportedVersions": {
-        // renovate: AGP version
         "8.9.0-alpha09": [
             "8.12"
         ],
-        // renovate: AGP version
         "8.8.0": [
             "8.12"
         ],
-        // renovate: AGP version
         "8.7.3": [
             "8.12"
         ],
-        // renovate: AGP version
         "8.6.1": [
             "8.12"
         ],
-        // renovate: AGP version
         "8.5.2": [
             "8.12"
         ],
-        // renovate: AGP version
         "8.4.2": [
             "8.12"
         ],
-        // renovate: AGP version
         "8.3.2": [
             "8.12"
         ],
-        // renovate: AGP version
         "8.2.2": [
             "8.12"
         ],
-        // renovate: AGP version
         "8.1.4": [
             "8.12"
         ],
-        // renovate: AGP version
         "8.0.2": [
             "8.0.2"
         ],
-        // renovate: AGP version
         "7.4.2": [
             "7.6.2"
         ],
-        // renovate: AGP version
         "7.3.1": [
             "7.4.2",
             "7.6.2"
         ],
-        // renovate: AGP version
         "7.2.2": [
             "7.3.3",
             "7.6.2"
         ],
-        // renovate: AGP version
         "7.1.3": [
             "7.2",
             "7.6.2"
         ],
-        // renovate: AGP version
         "7.0.4": [
             "7.0.2",
             "7.6.2"


### PR DESCRIPTION
In #1742, Renovate was set up with a more usual standard `regex` matcher configuration, which is to search for versions in lines annotated with a comment `// renovate: ...`. However, the `versions.json` file is parsed by several tools which don't support JSON5 or any form of comments, namely Groovy's `json` package and `jq`. Groovy `json` required using a lenient mode (#1742), which may suppress useful validations, while `jq` required stripping the comments beforehand (#1752). Moving away from JSON5 would be a simpler solution.

Revert the `versions.json` back from JSON5 to plain JSON and change the Renovate config to match the version properties based on the fact that their values are lists, e.g. `"8.8.0": [`. Matching the version in `gradle.properties` is also simplified to no longer require a comment.

Tested with a [dry-run of gradle/renovate-agent][2] against this repo and the Renovate GitHub app against a fork, which created an [example PR][1].

[1]: https://github.com/gabrielfeo/android-cache-fix-gradle-plugin/pull/14#issue-2787066376
[2]: https://github.com/gradle/renovate-agent/actions/runs/12771500371/job/35598810573