### PR TITLE
Move build versions to catalog

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -41,25 +41,18 @@ repositories {
 }
 
 dependencies {
-    val versions = mapOf(
-        "agp" to "8.1.4",
-        "sdkBuildTools" to "31.1.1",
-        "spock" to "2.3-groovy-3.0",
-    )
-
     compileOnly(gradleApi())
-    compileOnly("com.android.tools.build:gradle:${versions["agp"]}")
-    compileOnly("com.android.tools:common:${versions["sdkBuildTools"]}")
-    compileOnly("com.android.tools:sdk-common:${versions["sdkBuildTools"]}")
-    implementation("com.google.guava:guava:33.4.0-jre")
-
+    compileOnly(libs.android.tools.gradlePlugin)
+    compileOnly(libs.android.tools.common)
+    compileOnly(libs.android.tools.sdkCommon)
+    implementation(libs.guava)
 
     testImplementation(gradleTestKit())
-    testImplementation("com.android.tools.build:gradle:${versions["agp"]}")
-    testImplementation(platform("org.spockframework:spock-bom:${versions["spock"]}"))
-    testImplementation("org.spockframework:spock-core") { exclude(group = "org.codehaus.groovy") }
-    testImplementation("org.spockframework:spock-junit4") { exclude(group = "org.codehaus.groovy") }
-    testImplementation("org.junit.jupiter:junit-jupiter-api")
+    testImplementation(libs.android.tools.gradlePlugin)
+    testImplementation(platform(libs.spock.bom))
+    testImplementation(libs.spock.core) { exclude(group = "org.codehaus.groovy") }
+    testImplementation(libs.spock.junit4) { exclude(group = "org.codehaus.groovy") }
+    testImplementation(libs.junit.jupiter.api)
 }
 
 wrapperUpgrade {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,7 +11,7 @@ buildscript {
     dependencies {
         constraints {
             // Dependency of 'com.github.breadmoirai.github-release:2.5.2'
-            classpath("com.squareup.okio:okio:3.10.2") // CVE-2023-3635
+            classpath(libs.okio) // CVE-2023-3635
         }
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -42,13 +42,13 @@ repositories {
 
 dependencies {
     compileOnly(gradleApi())
-    compileOnly(libs.android.tools.gradlePlugin)
-    compileOnly(libs.android.tools.common)
-    compileOnly(libs.android.tools.sdkCommon)
+    compileOnly(libs.android.gradlePlugin)
+    compileOnly(libs.android.common)
+    compileOnly(libs.android.sdkCommon)
     implementation(libs.guava)
 
     testImplementation(gradleTestKit())
-    testImplementation(libs.android.tools.gradlePlugin)
+    testImplementation(libs.android.gradlePlugin)
     testImplementation(platform(libs.spock.bom))
     testImplementation(libs.spock.core) { exclude(group = "org.codehaus.groovy") }
     testImplementation(libs.spock.junit4) { exclude(group = "org.codehaus.groovy") }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,9 +22,9 @@ plugins {
     id("maven-publish")
     id("signing")
     id("codenarc")
-    id("com.gradle.plugin-publish") version "1.3.0"
-    id("com.github.breadmoirai.github-release") version "2.5.2"
-    id("org.gradle.wrapper-upgrade") version "0.12"
+    alias(libs.plugins.gradle.pluginPublish)
+    alias(libs.plugins.github.release)
+    alias(libs.plugins.gradle.wrapperUpgrade)
 }
 
 val releaseVersion = releaseVersion()

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,15 @@
+[versions]
+android-gradlePlugin = "8.1.4"
+android-sdkBuildTools = "31.1.1"
+spock = "2.3-groovy-3.0"
+guava = "33.4.0-jre"
+
+[libraries]
+android-tools-gradlePlugin = { module = "com.android.tools.build:gradle", version.ref = "android-gradlePlugin" }
+android-tools-common = { module = "com.android.tools:common", version.ref = "android-sdkBuildTools" }
+android-tools-sdkCommon = { module = "com.android.tools:sdk-common", version.ref = "android-sdkBuildTools" }
+guava = { module = "com.google.guava:guava", version.ref = "guava" }
+spock-bom = { module = "org.spockframework:spock-bom", version.ref = "spock" }
+spock-core = { module = "org.spockframework:spock-core" }
+spock-junit4 = { module = "org.spockframework:spock-junit4" }
+junit-jupiter-api = { module = "org.junit.jupiter:junit-jupiter-api" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,6 +6,7 @@ guava = "33.4.0-jre"
 gradle-pluginPublish = "1.3.0"
 gradle-wrapperUpgrade = "0.12"
 github-release = "2.5.2"
+okio = "3.10.2"
 
 [libraries]
 android-gradlePlugin = { module = "com.android.tools.build:gradle", version.ref = "android-gradlePlugin" }
@@ -16,6 +17,7 @@ spock-bom = { module = "org.spockframework:spock-bom", version.ref = "spock" }
 spock-core = { module = "org.spockframework:spock-core" }
 spock-junit4 = { module = "org.spockframework:spock-junit4" }
 junit-jupiter-api = { module = "org.junit.jupiter:junit-jupiter-api" }
+okio = { module = "com.squareup.okio:okio", version.ref = "okio" }
 
 [plugins]
 gradle-pluginPublish = { id = "com.gradle.plugin-publish", version.ref = "gradle-pluginPublish" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,25 +1,25 @@
 [versions]
 android-gradlePlugin = "8.1.4"
 android-sdkBuildTools = "31.1.1"
-spock = "2.3-groovy-3.0"
-guava = "33.4.0-jre"
+github-release = "2.5.2"
 gradle-pluginPublish = "1.3.0"
 gradle-wrapperUpgrade = "0.12"
-github-release = "2.5.2"
+guava = "33.4.0-jre"
 okio = "3.10.2"
+spock = "2.3-groovy-3.0"
 
 [libraries]
-android-gradlePlugin = { module = "com.android.tools.build:gradle", version.ref = "android-gradlePlugin" }
 android-common = { module = "com.android.tools:common", version.ref = "android-sdkBuildTools" }
+android-gradlePlugin = { module = "com.android.tools.build:gradle", version.ref = "android-gradlePlugin" }
 android-sdkCommon = { module = "com.android.tools:sdk-common", version.ref = "android-sdkBuildTools" }
 guava = { module = "com.google.guava:guava", version.ref = "guava" }
+junit-jupiter-api = { module = "org.junit.jupiter:junit-jupiter-api" }
+okio = { module = "com.squareup.okio:okio", version.ref = "okio" }
 spock-bom = { module = "org.spockframework:spock-bom", version.ref = "spock" }
 spock-core = { module = "org.spockframework:spock-core" }
 spock-junit4 = { module = "org.spockframework:spock-junit4" }
-junit-jupiter-api = { module = "org.junit.jupiter:junit-jupiter-api" }
-okio = { module = "com.squareup.okio:okio", version.ref = "okio" }
 
 [plugins]
+github-release = { id = "com.github.breadmoirai.github-release", version.ref = "github-release" }
 gradle-pluginPublish = { id = "com.gradle.plugin-publish", version.ref = "gradle-pluginPublish" }
 gradle-wrapperUpgrade = { id = "org.gradle.wrapper-upgrade", version.ref = "gradle-wrapperUpgrade" }
-github-release = { id = "com.github.breadmoirai.github-release", version.ref = "github-release" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,9 +5,9 @@ spock = "2.3-groovy-3.0"
 guava = "33.4.0-jre"
 
 [libraries]
-android-tools-gradlePlugin = { module = "com.android.tools.build:gradle", version.ref = "android-gradlePlugin" }
-android-tools-common = { module = "com.android.tools:common", version.ref = "android-sdkBuildTools" }
-android-tools-sdkCommon = { module = "com.android.tools:sdk-common", version.ref = "android-sdkBuildTools" }
+android-gradlePlugin = { module = "com.android.tools.build:gradle", version.ref = "android-gradlePlugin" }
+android-common = { module = "com.android.tools:common", version.ref = "android-sdkBuildTools" }
+android-sdkCommon = { module = "com.android.tools:sdk-common", version.ref = "android-sdkBuildTools" }
 guava = { module = "com.google.guava:guava", version.ref = "guava" }
 spock-bom = { module = "org.spockframework:spock-bom", version.ref = "spock" }
 spock-core = { module = "org.spockframework:spock-core" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,6 +3,9 @@ android-gradlePlugin = "8.1.4"
 android-sdkBuildTools = "31.1.1"
 spock = "2.3-groovy-3.0"
 guava = "33.4.0-jre"
+gradle-pluginPublish = "1.3.0"
+gradle-wrapperUpgrade = "0.12"
+github-release = "2.5.2"
 
 [libraries]
 android-gradlePlugin = { module = "com.android.tools.build:gradle", version.ref = "android-gradlePlugin" }
@@ -13,3 +16,8 @@ spock-bom = { module = "org.spockframework:spock-bom", version.ref = "spock" }
 spock-core = { module = "org.spockframework:spock-core" }
 spock-junit4 = { module = "org.spockframework:spock-junit4" }
 junit-jupiter-api = { module = "org.junit.jupiter:junit-jupiter-api" }
+
+[plugins]
+gradle-pluginPublish = { id = "com.gradle.plugin-publish", version.ref = "gradle-pluginPublish" }
+gradle-wrapperUpgrade = { id = "org.gradle.wrapper-upgrade", version.ref = "gradle-wrapperUpgrade" }
+github-release = { id = "com.github.breadmoirai.github-release", version.ref = "github-release" }


### PR DESCRIPTION
Move build versions to a version catalog so that they're properly picked up by Dependabot.