### PR TITLE
Clarify why older AGP and Spock are preferred

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,10 @@ updates:
     schedule:
       interval: "daily"
       time: "02:00"
+    # See libs.versions.toml for explanations
+    ignore:
+      - dependency-name: "com.android.tools.build:gradle"
+        versions: ["[8.2.0,)"]
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,4 +1,6 @@
 [versions]
+# AGP is kept at 8.1 because it includes all referenced classes.
+# Integration tests guarantee compatibility with newer AGP versions.
 android-gradlePlugin = "8.1.4"
 android-sdkBuildTools = "31.8.0"
 github-release = "2.5.2"
@@ -6,6 +8,8 @@ gradle-pluginPublish = "1.3.1"
 gradle-wrapperUpgrade = "0.12"
 guava = "33.4.0-jre"
 okio = "3.10.2"
+# Gradle plugins must use Groovy 3
+# https://docs.gradle.org/current/userguide/compatibility.html#groovy
 spock = "2.3-groovy-3.0"
 
 [libraries]


### PR DESCRIPTION
Clarifies why bumping AGP used for compiling isn't desired (#1762); prevents Dependabot from suggesting it.

Clarifies why bumping Spock to `*-groovy-4.0` versions (#1764) isn't desired. Dependabot not set to ignore these Spock versions because it's not clear how to define a Maven version range that would exclude only `2.x-groovy-4.0` versions.