### PR TITLE
Clarify workaround is still required for cache consistency across JDKs

### DIFF
--- a/src/main/groovy/org/gradle/android/workarounds/JdkImageWorkaround.groovy
+++ b/src/main/groovy/org/gradle/android/workarounds/JdkImageWorkaround.groovy
@@ -41,7 +41,7 @@ import java.util.stream.Stream
  *
  * As a result, the workaround remains necessary to guarantee cache hits between environments.
  *
- * */
+ */
 @AndroidIssue(introducedIn = "7.1.0", link = "https://issuetracker.google.com/u/1/issues/234820480")
 class JdkImageWorkaround implements Workaround {
     static final String WORKAROUND_ENABLED_PROPERTY = "org.gradle.android.cache-fix.JdkImageWorkaround.enabled"

--- a/src/main/groovy/org/gradle/android/workarounds/JdkImageWorkaround.groovy
+++ b/src/main/groovy/org/gradle/android/workarounds/JdkImageWorkaround.groovy
@@ -34,7 +34,14 @@ import java.util.stream.Stream
  * Works around cache misses due to the custom Java runtime used when source compatibility is set higher
  * than Java 9.  This normalizes out minor inconsequential differences between JDKs used to generate the
  * custom runtime and improve cache hits between environments.
- */
+ *
+ * Although this issue was marked as fixed in AGP 7.4.0-alpha07, we are still able to reproduce cache misses
+ * with different JDK vendors in recent AGP and JDK versions.
+ * Example: https://ge.solutions-team.gradle.com/c/fpylyt2yu7c26/gneeakcvrhijs/task-inputs
+ *
+ * As a result, the workaround remains necessary to guarantee cache hits between environments.
+ *
+ * */
 @AndroidIssue(introducedIn = "7.1.0", link = "https://issuetracker.google.com/u/1/issues/234820480")
 class JdkImageWorkaround implements Workaround {
     static final String WORKAROUND_ENABLED_PROPERTY = "org.gradle.android.cache-fix.JdkImageWorkaround.enabled"


### PR DESCRIPTION
Issue #1851 raised the question again about whether the `JdkImageWorkaround` is still necessary. This isn’t the first time the same concern has been brought up by users — see [#1834](https://github.com/gradle/android-cache-fix-gradle-plugin/pull/1834).

Internally, we’ve been conducting yearly investigations comparing builds using different JDK vendors across recent AGP and JDK versions. In every case so far, we’ve confirmed that the issue persists. However, we haven’t previously shared these findings publicly.

The workaround remains valid because it increases remote cache hits for the affected tasks by mitigating these differences.

For example, in this year’s evaluation using AGP 8.9, we observed the following:

<img width="680" height="237" alt="Screenshot 2025-07-16 at 4 10 42 PM" src="https://github.com/user-attachments/assets/b9b3c2e0-97ac-49a1-a0e9-cbf1e1822b22" />

Without the workaround, JDK versions 17, 21, 22, and 23 exhibited the issue in at least one comparison involving different vendors. In particular, with JDK 21, the problem still surfaced when using Zulu:

<img width="652" height="543" alt="Screenshot 2025-07-16 at 4 11 04 PM" src="https://github.com/user-attachments/assets/7e94aef3-a8a7-4862-93da-24d679ded8c3" />



This PR adds a comment to the workaround to clarify why it is still in use and why it continues to be necessary.