### PR TITLE
Changed wrapper bot gh token from readonly to GH_BOT_GITHUB_TOKEN

### DIFF
--- a/.github/workflows/wrapper-upgrade-execution.yml
+++ b/.github/workflows/wrapper-upgrade-execution.yml
@@ -37,4 +37,4 @@ jobs:
       - name: Upgrade Wrappers
         run: ./gradlew clean upgradeGradleWrapperAll --continue -Porg.gradle.java.installations.auto-download=false
         env:
-          WRAPPER_UPGRADE_GIT_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          WRAPPER_UPGRADE_GIT_TOKEN: ${{ secrets.GH_BOT_GITHUB_TOKEN }}


### PR DESCRIPTION
This allows PRs created by the wrapperbot to trigger workflows on the pull_request trigger. 