### PR TITLE
Adding test classes configuration

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -162,8 +162,11 @@ check(latestVersion.get() in testedVersions) {
     "The project must be updated to support AGP $latestVersion. Please add it to tested versions."
 }
 
+val test by testing.suites.existing(JvmTestSuite::class)
 testedVersions.keys.forEach { androidVersion ->
     val versionSpecificTest = tasks.register<Test>(androidTestTaskName(androidVersion)) {
+        testClassesDirs = files(test.map { it.sources.output.classesDirs })
+        classpath = files(test.map { it.sources.runtimeClasspath })
         description = "Runs the multi-version tests for AGP $androidVersion"
         group = "verification"
 


### PR DESCRIPTION
While testing the AGP9 branch, I made some changes and was surprised that the CI checks finished immediately. After reviewing the build scans, I observed that no tests were executed:
https://ge.solutions-team.gradle.com/s/xnnyxy3b32gry/tests/overview

The timeline shows that the test task has the outcome "NO-SOURCE."
<img width="887" height="178" alt="Screenshot 2025-08-19 at 4 03 42 PM" src="https://github.com/user-attachments/assets/06ebb26b-36d3-449f-96b9-de979a8e9935" />

This behavior is documented in the upgrading release notes:
https://docs.gradle.org/9.0.0/userguide/upgrading_major_version_9.html#test_tasks_may_no_longer_execute_expected_tests

This PR adds test class configurations for the test version tasks, and the test tasks are now executing as expected:
https://ge.solutions-team.gradle.com/s/bxi65rplucida/tests/overview
