### PR TITLE
Missing AGP versions in WorkaroundTest

### DIFF
--- a/src/test/groovy/org/gradle/android/WorkaroundTest.groovy
+++ b/src/test/groovy/org/gradle/android/WorkaroundTest.groovy
@@ -12,6 +12,11 @@ class WorkaroundTest extends Specification {
         workarounds.collect { it.class.simpleName.replaceAll(/Workaround/, "") }.sort() == expectedWorkarounds.sort()
         where:
         androidVersion | expectedWorkarounds
+        "9.0"          | ['JdkImage']
+        "8.13"         | ['JdkImage']
+        "8.12"         | ['JdkImage']
+        "8.11"         | ['JdkImage']
+        "8.10"         | ['JdkImage']
         "8.9"          | ['JdkImage']
         "8.8"          | ['JdkImage']
         "8.7"          | ['JdkImage']


### PR DESCRIPTION
Missing AGP versions in WorkaroundTest