### PR TITLE
Fix Provider.toString() in AGP version check error message

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -154,7 +154,7 @@ val latestVersion = providers.gradleProperty("org.gradle.android.latestKnownAgpV
 val testedVersions = readTestedVersions()
 
 check(latestVersion.get() in testedVersions) {
-    "The project must be updated to support AGP $latestVersion. Please add it to tested versions."
+    "The project must be updated to support AGP ${latestVersion.get()}. Please add it to tested versions."
 }
 
 val test by testing.suites.existing(JvmTestSuite::class)


### PR DESCRIPTION
## Summary

The AGP version check error message on `build.gradle.kts:157` interpolates the `Provider<String>` object directly (`$latestVersion`) instead of its value (`${latestVersion.get()}`), causing the error to display `provider(?)` rather than the actual version string.

See this [build scan](https://ge.solutions-team.gradle.com/s/vtwqaaucqh3e2) for an example where the error reads:

> The project must be updated to support AGP provider(?). Please add it to tested versions.