### PR TITLE
Ungroup AGP version updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -53,19 +53,6 @@
       "ignoreUnstable": false,
     },
     {
-      // Customize commit message for AGP version changes
-      "matchFileNames": [
-        "src/test/resources/versions\\.json",
-        "gradle\\.properties",
-      ],
-      "commitMessageTopic": "tested AGP versions",
-    },
-    {
-      // Ignore broken 9.2.0-rc01
-      "matchDepNames": ["com.android.tools.build:gradle"],
-      "allowedVersions": "!/^9\\.2\\.0-rc01$/",
-    },
-    {
       // AGP is managed by the custom regex manager for the test matrix
       "matchManagers": ["gradle"],
       "matchDepNames": ["com.android.tools.build:gradle"],

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -53,13 +53,17 @@
       "ignoreUnstable": false,
     },
     {
-      // Group changes about AGP versions
+      // Customize commit message for AGP version changes
       "matchFileNames": [
         "src/test/resources/versions\\.json",
         "gradle\\.properties",
       ],
       "commitMessageTopic": "tested AGP versions",
-      "groupName": "tested AGP versions",
+    },
+    {
+      // Ignore broken 9.2.0-rc01
+      "matchDepNames": ["com.android.tools.build:gradle"],
+      "allowedVersions": "!/^9\\.2\\.0-rc01$/",
     },
     {
       // AGP is managed by the custom regex manager for the test matrix


### PR DESCRIPTION
## Summary
This is to help unblock the 9.1.0 → 9.1.1 update from #1989.