### PR TITLE
Update Universal Cache setup to CLI 1.3.0 and public download

### DIFF
--- a/.github/actions/setup-and-restore-artifact-cache/action.yml
+++ b/.github/actions/setup-and-restore-artifact-cache/action.yml
@@ -5,7 +5,6 @@ runs:
   using: 'composite'
   steps:
     - name: Provision and configure Artifact Cache
-      if: env.ARTIFACT_CACHE_REPO_PASSWORD != ''
       shell: bash
       run: |
         TOOL_DIR="${{ runner.tool_cache }}/develocity/artifact-cache/${{ env.ARTIFACT_CACHE_CLI_VERSION }}"
@@ -18,24 +17,30 @@ runs:
         curl --location --fail --silent --show-error \
          --connect-timeout 5 --max-time 30 \
          --retry 3 --retry-delay 3 --retry-max-time 60 \
-         --user "$ARTIFACT_CACHE_REPO_USERNAME:$ARTIFACT_CACHE_REPO_PASSWORD" \
-         "${{ env.ARTIFACT_CACHE_REPO }}/com/gradle/${{ env.ARTIFACT_CACHE_CLI_FILENAME }}/${{ env.ARTIFACT_CACHE_CLI_VERSION }}/${{ env.ARTIFACT_CACHE_CLI_FILENAME }}-${{ env.ARTIFACT_CACHE_CLI_VERSION }}.jar" \
+         "https://docs.gradle.com/downloads/develocity-artifact-cache-cli/develocity-artifact-cache-cli-${{ env.ARTIFACT_CACHE_CLI_VERSION }}.jar" \
          --output "$JAR_PATH"
+
+        # Verify SHA-256 checksum
+        curl --location --fail --silent --show-error \
+         "https://docs.gradle.com/downloads/develocity-artifact-cache-cli/develocity-artifact-cache-cli-${{ env.ARTIFACT_CACHE_CLI_VERSION }}.jar.sha256" \
+         --output "$JAR_PATH.sha256"
+        echo "$(cat "$JAR_PATH.sha256") $JAR_PATH" | sha256sum --check
+        rm "$JAR_PATH.sha256"
         fi
 
         CMD="${{ env[format('JAVA_HOME_21_{0}', runner.arch)] }}/bin/java -jar $JAR_PATH"
-        echo "ARTIFACT_CACHE_CMD=$CMD" >> $GITHUB_ENV
+        echo "ARTIFACT_CACHE_CMD=$CMD" >> "$GITHUB_ENV"
 
         CMD_OPTS="--dv-server=$DV_SERVER ${ARTIFACT_CACHE_IMAGE:+--image-name=$ARTIFACT_CACHE_IMAGE} $ARTIFACT_CACHE_OPTS"
-        echo "ARTIFACT_CACHE_CMD_OPTS=$CMD_OPTS" >> $GITHUB_ENV
+        echo "ARTIFACT_CACHE_CMD_OPTS=$CMD_OPTS" >> "$GITHUB_ENV"
 
     - name: Restore from Artifact Cache
-      if: env.ARTIFACT_CACHE_REPO_PASSWORD != ''
       id: restore_cache
+      continue-on-error: true
       shell: bash
       run: $ARTIFACT_CACHE_CMD restore $ARTIFACT_CACHE_CMD_OPTS
 
     - name: Warn on Cache Restore Failure
-      if: env.ARTIFACT_CACHE_REPO_PASSWORD != '' && steps.restore_cache.outcome == 'failure'
+      if: steps.restore_cache.outcome == 'failure'
       shell: bash
       run: 'echo "WARNING: Could not restore the Artifact Cache. The build will proceed but may be slower."'

--- a/.github/actions/store-artifact-cache/action.yml
+++ b/.github/actions/store-artifact-cache/action.yml
@@ -10,19 +10,18 @@ runs:
   using: 'composite'
   steps:
     - name: Store to Artifact Cache
-      if: success() && env.ARTIFACT_CACHE_REPO_PASSWORD != ''
+      if: success()
       id: store_cache
       continue-on-error: true
       shell: bash
       run: $ARTIFACT_CACHE_CMD store $ARTIFACT_CACHE_CMD_OPTS
 
     - name: Warn on Cache Store Failure
-      if: env.ARTIFACT_CACHE_REPO_PASSWORD != '' && steps.store_cache.outcome == 'failure'
+      if: steps.store_cache.outcome == 'failure'
       shell: bash
       run: 'echo "WARNING: Failed to store in the Artifact Cache."'
 
     - name: Persist Artifact Cache Logs
-      if: env.ARTIFACT_CACHE_REPO_PASSWORD != ''
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       with:
         name: ${{ inputs.artifact-name }}

--- a/.github/workflows/build-verification.yml
+++ b/.github/workflows/build-verification.yml
@@ -10,21 +10,17 @@ permissions:
   contents: read
 
 env:
-  # Artifact Cache Configuration
-  ARTIFACT_CACHE_CLI_VERSION: 0.10.0
+  # Artifact Cache CLI Configuration
+  ARTIFACT_CACHE_CLI_VERSION: 1.3.0
 
   # Develocity
   DV_SERVER: https://ge.solutions-team.gradle.com
   DEVELOCITY_ACCESS_KEY: ${{ secrets.DV_SOLUTIONS_ACCESS_KEY }}
 
-  # Artifact Cache CLI
-  ARTIFACT_CACHE_REPO_USERNAME: ${{ secrets.ARTIFACT_CACHE_REPO_USERNAME }}
-  ARTIFACT_CACHE_REPO_PASSWORD: ${{ secrets.ARTIFACT_CACHE_REPO_PASSWORD }}
-  ARTIFACT_CACHE_REPO: ${{ secrets.ARTIFACT_CACHE_REPO }}
-
   # Misc
   ARTIFACT_CACHE_CLI_FILENAME: develocity-artifact-cache-cli
   ARTIFACT_CACHE_OPTS: "--gradle-home=/home/runner/.gradle"
+  ARTIFACT_CACHE_STORE: "true"
 
 jobs:
   generate_versions:
@@ -59,12 +55,13 @@ jobs:
         with:
           cache-disabled: true
           develocity-access-key: ${{ secrets.DV_SOLUTIONS_ACCESS_KEY }}
-      - name: Setup and restore Artifact Cache
+      - name: Setup and restore Universal Cache
         uses: ./.github/actions/setup-and-restore-artifact-cache
       - name: Run sanityCheck
         run: ./gradlew sanityCheck -Porg.gradle.java.installations.auto-download=false
-      - name: Store Artifact Cache
+      - name: Store Universal Cache
         uses: ./.github/actions/store-artifact-cache
+        if: env.ARTIFACT_CACHE_STORE == 'true'
         with:
           artifact-name: artifact-cache-${{ github.job }}.log
 
@@ -82,7 +79,7 @@ jobs:
         with:
           cache-disabled: true
           develocity-access-key: ${{ secrets.DV_SOLUTIONS_ACCESS_KEY }}
-      - name: Setup and restore Artifact Cache
+      - name: Setup and restore Universal Cache
         uses: ./.github/actions/setup-and-restore-artifact-cache
       - name: Run unit tests
         run: >-
@@ -93,8 +90,9 @@ jobs:
             -Dpts.mode=$PTS_MODE
         env:
           PTS_MODE: "${{ github.ref_name == 'main' && 'REMAINING_TESTS' || 'RELEVANT_TESTS' }}"
-      - name: Store Artifact Cache
+      - name: Store Universal Cache
         uses: ./.github/actions/store-artifact-cache
+        if: env.ARTIFACT_CACHE_STORE == 'true'
         with:
           artifact-name: artifact-cache-${{ github.job }}.log
 
@@ -144,7 +142,7 @@ jobs:
         with:
           cache-disabled: true
           develocity-access-key: ${{ secrets.DV_SOLUTIONS_ACCESS_KEY }}
-      - name: Setup and restore Artifact Cache
+      - name: Setup and restore Universal Cache
         uses: ./.github/actions/setup-and-restore-artifact-cache
       - name: Run integration tests
         run: >-
@@ -155,8 +153,9 @@ jobs:
             -Dpts.mode=$PTS_MODE
         env:
           PTS_MODE: "${{ github.ref_name == 'main' && 'REMAINING_TESTS' || 'RELEVANT_TESTS' }}"
-      - name: Store Artifact Cache
+      - name: Store Universal Cache
         uses: ./.github/actions/store-artifact-cache
+        if: env.ARTIFACT_CACHE_STORE == 'true'
         with:
           artifact-name: artifact-cache-${{ github.job }}-${{ matrix.versions }}.log
 


### PR DESCRIPTION
## What

Updates the Artifact/Universal Cache configuration in CI to match the current [`common-custom-user-data-gradle-plugin`](https://github.com/gradle/common-custom-user-data-gradle-plugin/blob/main/.github/workflows/build-verification.yml) approach and the latest CLI (1.3.0). The previous config used CLI `0.10.0` and downloaded the jar from an authenticated private repo.

## Changes

**`.github/workflows/build-verification.yml`**
- Bump `ARTIFACT_CACHE_CLI_VERSION` `0.10.0` → `1.3.0`
- Remove the private-repo secrets (`ARTIFACT_CACHE_REPO_USERNAME` / `ARTIFACT_CACHE_REPO_PASSWORD` / `ARTIFACT_CACHE_REPO`)
- Add an `ARTIFACT_CACHE_STORE: "true"` toggle, gating each store step with `if: env.ARTIFACT_CACHE_STORE == 'true'`
- Rename steps to "Universal Cache"

**`.github/actions/setup-and-restore-artifact-cache/action.yml`**
- Download the CLI from the public `docs.gradle.com` URL instead of the authenticated private repo
- Verify the downloaded jar's SHA-256 checksum
- Drop the `ARTIFACT_CACHE_REPO_PASSWORD != ''` gating
- Restore step now uses `continue-on-error: true` so a cache miss/failure never fails the build

**`.github/actions/store-artifact-cache/action.yml`**
- Remove `ARTIFACT_CACHE_REPO_PASSWORD` gating; store is now controlled at the workflow level via `ARTIFACT_CACHE_STORE`

## Notes

The `ARTIFACT_CACHE_REPO*` repo secrets are no longer referenced and can be removed from repo settings. `DV_SOLUTIONS_ACCESS_KEY` is still required for Develocity.