### PR TITLE
Bump Artifact Cache CLI version to 1.4.0

### DIFF
--- a/.github/workflows/build-verification.yml
+++ b/.github/workflows/build-verification.yml
@@ -11,7 +11,7 @@ permissions:
 
 env:
   # Artifact Cache CLI Configuration
-  ARTIFACT_CACHE_CLI_VERSION: 1.3.0
+  ARTIFACT_CACHE_CLI_VERSION: 1.4.0
 
   # Develocity
   DV_SERVER: https://ge.solutions-team.gradle.com


### PR DESCRIPTION
Bumps the Develocity Artifact Cache CLI from `1.3.0` to `1.4.0`.

The CLI is downloaded from the public `docs.gradle.com` URL with SHA-256 checksum verification, so no other changes are needed — only the `ARTIFACT_CACHE_CLI_VERSION` env var in the build-verification workflow.

- `develocity-artifact-cache-cli-1.4.0.jar` and its `.sha256` are available at `https://docs.gradle.com/downloads/develocity-artifact-cache-cli/`.