### PR TITLE
Replace stale gradle.com references with develocity.ai

### DIFF
--- a/.github/actions/setup-and-restore-artifact-cache/action.yml
+++ b/.github/actions/setup-and-restore-artifact-cache/action.yml
@@ -17,12 +17,12 @@ runs:
         curl --location --fail --silent --show-error \
          --connect-timeout 5 --max-time 30 \
          --retry 3 --retry-delay 3 --retry-max-time 60 \
-         "https://docs.gradle.com/downloads/develocity-artifact-cache-cli/develocity-artifact-cache-cli-${{ env.ARTIFACT_CACHE_CLI_VERSION }}.jar" \
+         "https://docs.develocity.ai/downloads/develocity-artifact-cache-cli/develocity-artifact-cache-cli-${{ env.ARTIFACT_CACHE_CLI_VERSION }}.jar" \
          --output "$JAR_PATH"
 
         # Verify SHA-256 checksum
         curl --location --fail --silent --show-error \
-         "https://docs.gradle.com/downloads/develocity-artifact-cache-cli/develocity-artifact-cache-cli-${{ env.ARTIFACT_CACHE_CLI_VERSION }}.jar.sha256" \
+         "https://docs.develocity.ai/downloads/develocity-artifact-cache-cli/develocity-artifact-cache-cli-${{ env.ARTIFACT_CACHE_CLI_VERSION }}.jar.sha256" \
          --output "$JAR_PATH.sha256"
         echo "$(cat "$JAR_PATH.sha256") $JAR_PATH" | sha256sum --check
         rm "$JAR_PATH.sha256"

--- a/README.md
+++ b/README.md
@@ -182,5 +182,5 @@ The Android Cache Fix Gradle plugin is open-source software released under the [
 [develocity-build-validation-scripts]: https://github.com/gradle/develocity-build-validation-scripts
 [develocity-oss-projects]: https://github.com/gradle/develocity-oss-projects
 [quarkus-build-caching-extension]: https://github.com/gradle/quarkus-build-caching-extension
-[develocity]: https://gradle.com/develocity
+[develocity]: https://develocity.ai/
 [apache-license]: https://www.apache.org/licenses/LICENSE-2.0.html

--- a/README.md
+++ b/README.md
@@ -182,5 +182,5 @@ The Android Cache Fix Gradle plugin is open-source software released under the [
 [develocity-build-validation-scripts]: https://github.com/gradle/develocity-build-validation-scripts
 [develocity-oss-projects]: https://github.com/gradle/develocity-oss-projects
 [quarkus-build-caching-extension]: https://github.com/gradle/quarkus-build-caching-extension
-[develocity]: https://develocity.ai/
+[develocity]: https://develocity.ai
 [apache-license]: https://www.apache.org/licenses/LICENSE-2.0.html

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -106,7 +106,7 @@ publishing {
                     developer {
                         name.set("The Gradle team")
                         organization.set("Gradle Inc.")
-                        organizationUrl.set("https://gradle.com")
+                        organizationUrl.set("https://develocity.ai")
                     }
                 }
                 scm {


### PR DESCRIPTION
Updates stale `gradle.com` references to their current canonical destinations. `gradle.com` and `docs.gradle.com` URLs now redirect to `develocity.ai` / `docs.develocity.ai`; this updates them to the canonical hosts.

**Changes**
- `action.yml` (artifact-cache): Artifact Cache CLI download `docs.gradle.com/downloads/...` → `docs.develocity.ai/downloads/...` (host swap; path unchanged)
- `README.md`: `[develocity]` link `gradle.com/develocity` → `develocity.ai/`
- `build.gradle.kts`: publishing `organizationUrl` → `https://develocity.ai`

⚠️ **Review note**: the `docs.gradle.com/enterprise/tutorials/task-inputs-comparison/` link was left unchanged — it still resolves on `docs.gradle.com`, and I couldn't locate a confident `docs.develocity.ai` equivalent. Please remap if one exists.
